### PR TITLE
Fix Flutter auth provider usage

### DIFF
--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
-import '../providers/auth_provider.dart'; // ✅ 추가
+import '../providers/auth_provider.dart';
 
 class CreateGroupPage extends ConsumerWidget {
   const CreateGroupPage({Key? key}) : super(key: key);
@@ -9,7 +9,7 @@ class CreateGroupPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nameController = TextEditingController();
-    final auth = ref.watch(authProvider); // ✅ 기존 방식 유지
+    final token = ref.watch(tokenProvider);
     bool hasAdmin = false;
 
     return Scaffold(
@@ -35,7 +35,7 @@ class CreateGroupPage extends ConsumerWidget {
                 final result = await ref.read(groupServiceProvider).createGroup(
                   name: nameController.text,
                   hasAdmin: hasAdmin,
-                  token: auth.token, // ✅ 여기서 기존 구조 사용
+                  token: token,
                 );
 
                 showDialog(


### PR DESCRIPTION
## Summary
- fix CreateGroupPage to use `tokenProvider` instead of undefined `authProvider`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686289f15ae88324938269e22c3963f5