### PR TITLE
Remove admin option from group creation

### DIFF
--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -10,7 +10,6 @@ class CreateGroupPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final nameController = TextEditingController();
     final token = ref.watch(tokenProvider);
-    bool hasAdmin = false;
 
     return Scaffold(
       appBar: AppBar(title: Text('그룹 생성')),
@@ -19,22 +18,10 @@ class CreateGroupPage extends ConsumerWidget {
         child: Column(
           children: [
             TextField(controller: nameController, decoration: InputDecoration(labelText: '그룹 이름')),
-            Row(
-              children: [
-                Checkbox(
-                  value: hasAdmin,
-                  onChanged: (value) {
-                    hasAdmin = value ?? false;
-                  },
-                ),
-                Text('관리자 있음'),
-              ],
-            ),
             ElevatedButton(
               onPressed: () async {
                 final result = await ref.read(groupServiceProvider).createGroup(
                   name: nameController.text,
-                  hasAdmin: hasAdmin,
                   token: token,
                 );
 

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -8,7 +8,6 @@ class GroupService {
   // 🔹 그룹 생성 (JWT 토큰 기반 인증)
   Future<Map<String, dynamic>> createGroup({
     required String name,
-    required bool hasAdmin,
     required String token,
   }) async {
     try {
@@ -16,7 +15,6 @@ class GroupService {
         '/api/groups/create',
         data: {
           'name': name,
-          'hasAdmin': hasAdmin,
         },
         options: Options(
           headers: {


### PR DESCRIPTION
## Summary
- streamline `CreateGroupPage` by removing unused checkbox
- adjust `GroupService` to stop sending `hasAdmin`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f3422248324b8ffb83b317ae695