### PR TITLE
Improve CreateGroupPage validation

### DIFF
--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -3,49 +3,92 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
 import '../providers/auth_provider.dart';
 
-class CreateGroupPage extends ConsumerWidget {
+class CreateGroupPage extends ConsumerStatefulWidget {
   const CreateGroupPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final nameController = TextEditingController();
-    final token = ref.watch(tokenProvider);
-    bool hasAdmin = false;
+  ConsumerState<CreateGroupPage> createState() => _CreateGroupPageState();
+}
 
+class _CreateGroupPageState extends ConsumerState<CreateGroupPage> {
+  final TextEditingController _nameController = TextEditingController();
+  bool _hasAdmin = false;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleCreate() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('그룹 이름을 입력해주세요')),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final token = ref.read(tokenProvider);
+      final result = await ref.read(groupServiceProvider).createGroup(
+        name: name,
+        hasAdmin: _hasAdmin,
+        token: token,
+      );
+
+      if (!mounted) return;
+      await showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('그룹 생성 완료'),
+          content: Text('초대코드: ${result['invitationCode']}'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('확인'),
+            )
+          ],
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.toString())),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('그룹 생성')),
+      appBar: AppBar(title: const Text('그룹 생성')),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            TextField(controller: nameController, decoration: InputDecoration(labelText: '그룹 이름')),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: '그룹 이름'),
+            ),
             Row(
               children: [
                 Checkbox(
-                  value: hasAdmin,
-                  onChanged: (value) {
-                    hasAdmin = value ?? false;
-                  },
+                  value: _hasAdmin,
+                  onChanged: (value) => setState(() => _hasAdmin = value ?? false),
                 ),
-                Text('관리자 있음'),
+                const Text('관리자 있음'),
               ],
             ),
+            const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () async {
-                final result = await ref.read(groupServiceProvider).createGroup(
-                  name: nameController.text,
-                  hasAdmin: hasAdmin,
-                  token: token,
-                );
-
-                showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    content: Text('초대코드: ${result['invitationCode']}'),
-                  ),
-                );
-              },
-              child: Text('생성'),
+              onPressed: _isLoading ? null : _handleCreate,
+              child: Text(_isLoading ? '생성 중...' : '생성'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -25,6 +25,9 @@ class GroupService {
         ),
       );
       return response.data;
+    } on DioError catch (e) {
+      final message = e.response?.data['message'] ?? e.message;
+      throw Exception(message);
     } catch (e) {
       throw Exception('그룹 생성 실패: $e');
     }


### PR DESCRIPTION
## Summary
- validate group name before calling API
- convert `CreateGroupPage` to `ConsumerStatefulWidget`
- show API error messages from the backend
- display loading state while creating a group
- propagate backend message in `GroupService`

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` in backend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68628f36efa8832484d5e5125eda3067