### PR TITLE
Navigate to group board after creation

### DIFF
--- a/private_board_backend/pages/api/groups/[id]/posts.ts
+++ b/private_board_backend/pages/api/groups/[id]/posts.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '@/lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  try {
+    const posts = await prisma.post.findMany({
+      where: { groupId: id as string },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        author: {
+          select: {
+            id: true,
+            email: true,
+          },
+        },
+      },
+    });
+    return res.status(200).json(posts);
+  } catch (error) {
+    console.error('❌ Group posts fetch error:', error);
+    return res.status(500).json({ message: 'Failed to fetch posts' });
+  }
+}

--- a/private_board_frontend/lib/main.dart
+++ b/private_board_frontend/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'pages/login_page.dart';
-import 'pages/post_list_page.dart';
+import 'pages/group_home_page.dart';
 import 'services/auth_service.dart';
 
 void main() {
@@ -17,11 +17,12 @@ class MyApp extends StatelessWidget {
 
   Future<Widget> getStartPage() async {
     final token = await AuthService.getToken();
-    print('앱 시작 토큰 체크: "$token"'); // (디버깅용)
-    if (token == null || token.isEmpty) {
+    final userId = await AuthService.getUserId();
+    print('앱 시작 토큰 체크: "$token"');
+    if (token == null || token.isEmpty || userId == null) {
       return const LoginPage();
     } else {
-      return const PostListPage(); // TODO: 향후 GroupHomePage로 변경해도 됨
+      return GroupHomePage(userId: userId);
     }
   }
 

--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -2,15 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
 import '../providers/auth_provider.dart';
+import 'post_list_page.dart';
 
-class CreateGroupPage extends ConsumerWidget {
+class CreateGroupPage extends ConsumerStatefulWidget {
   const CreateGroupPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final nameController = TextEditingController();
+  ConsumerState<CreateGroupPage> createState() => _CreateGroupPageState();
+}
+
+class _CreateGroupPageState extends ConsumerState<CreateGroupPage> {
+  final nameController = TextEditingController();
+  bool hasAdmin = false;
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final token = ref.watch(tokenProvider);
-    bool hasAdmin = false;
 
     return Scaffold(
       appBar: AppBar(title: Text('그룹 생성')),
@@ -24,10 +37,12 @@ class CreateGroupPage extends ConsumerWidget {
                 Checkbox(
                   value: hasAdmin,
                   onChanged: (value) {
-                    hasAdmin = value ?? false;
+                    setState(() {
+                      hasAdmin = value ?? false;
+                    });
                   },
                 ),
-                Text('관리자 있음'),
+                const Text('관리자 있음'),
               ],
             ),
             ElevatedButton(
@@ -38,12 +53,20 @@ class CreateGroupPage extends ConsumerWidget {
                   token: token,
                 );
 
-                showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    content: Text('초대코드: ${result['invitationCode']}'),
-                  ),
-                );
+                final groupId = result['groupId'] as String?;
+                final code = result['invitationCode'] as String?;
+
+                if (groupId != null) {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PostListPage(
+                        groupId: groupId,
+                        invitationCode: hasAdmin ? code : null,
+                      ),
+                    ),
+                  );
+                }
               },
               child: Text('생성'),
             ),

--- a/private_board_frontend/lib/pages/post_list_page.dart
+++ b/private_board_frontend/lib/pages/post_list_page.dart
@@ -6,7 +6,11 @@ import '../services/auth_service.dart';
 import '../pages/login_page.dart';
 
 class PostListPage extends StatefulWidget {
-  const PostListPage({super.key});
+  final String groupId;
+  final String? invitationCode;
+
+  const PostListPage({Key? key, required this.groupId, this.invitationCode})
+      : super(key: key);
 
   @override
   State<PostListPage> createState() => _PostListPageState();
@@ -20,6 +24,11 @@ class _PostListPageState extends State<PostListPage> {
   void initState() {
     super.initState();
     _initPage();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.invitationCode != null) {
+        _showInvitationDialog(widget.invitationCode!);
+      }
+    });
   }
 
   Future<void> _initPage() async {
@@ -40,7 +49,7 @@ class _PostListPageState extends State<PostListPage> {
 
   Future<void> loadPosts() async {
     print('[PostListPage] loadPosts 호출');
-    final data = await PostApi.fetchPosts();
+    final data = await PostApi.fetchGroupPosts(widget.groupId);
     print('[PostListPage] 받아온 글 개수: ${data.length}');
     setState(() {
       posts = data;
@@ -57,6 +66,22 @@ class _PostListPageState extends State<PostListPage> {
     );
   }
 
+  void _showInvitationDialog(String code) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('초대 코드'),
+        content: SelectableText(code),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     print('[PostListPage] build 호출, posts 길이: ${posts.length}, loading: $_loading');
@@ -65,6 +90,12 @@ class _PostListPageState extends State<PostListPage> {
       appBar: AppBar(
         title: const Text('🌿 따뜻한 하루'),
         actions: [
+          if (widget.invitationCode != null)
+            IconButton(
+              icon: const Icon(Icons.admin_panel_settings),
+              tooltip: '초대 코드',
+              onPressed: () => _showInvitationDialog(widget.invitationCode!),
+            ),
           IconButton(
             icon: const Icon(Icons.logout),
             tooltip: "로그아웃",

--- a/private_board_frontend/lib/services/post_api.dart
+++ b/private_board_frontend/lib/services/post_api.dart
@@ -38,6 +38,28 @@ class PostApi {
     }
   }
 
+  /// 🔍 특정 그룹의 게시글 목록 조회
+  static Future<List<dynamic>> fetchGroupPosts(String groupId) async {
+    final token = await _getToken();
+    final url = '$_baseUrl/api/groups/$groupId/posts';
+    try {
+      final response = await _dio.get(
+        url,
+        options: Options(
+          headers: {
+            if (token != null) 'Authorization': 'Bearer $token',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+      return response.data;
+    } catch (e, stack) {
+      print('❌ 그룹 게시글 조회 실패: $e');
+      print('스택 트레이스: $stack');
+      return [];
+    }
+  }
+
   /// ✍️ 게시글 등록
   static Future<bool> create(String title, String content) async {
     final token = await _getToken();


### PR DESCRIPTION
## Summary
- fetch posts belonging to a group via new API endpoint
- display invitation code menu in PostListPage when user is admin
- push PostListPage after creating a group
- update start page to navigate to GroupHomePage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f39b5d48324b04863fd06169ed5