### PR TITLE
Enable direct group join via code

### DIFF
--- a/private_board_backend/pages/api/groups/join.ts
+++ b/private_board_backend/pages/api/groups/join.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from 'private_board_backend/prisma'; // 경로 수정됨
+import { prisma } from '@/lib/prisma';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -21,7 +21,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(404).json({ message: '초대코드가 유효하지 않습니다.' });
   }
 
-  const user = await prisma.user.update({
+  await prisma.user.update({
     where: { id: String(userId) },
     data: { groupId: group.id },
   });

--- a/private_board_frontend/lib/pages/join_group_page.dart
+++ b/private_board_frontend/lib/pages/join_group_page.dart
@@ -14,12 +14,10 @@ class JoinGroupPage extends ConsumerStatefulWidget {
 class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
 
   final codeController = TextEditingController();
-  final messageController = TextEditingController(); // ✅ 이 줄 추가
 
   @override
   void dispose() {
     codeController.dispose();
-    messageController.dispose(); // ✅ 함께 dispose
     super.dispose();
   }
 
@@ -37,27 +35,19 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
               decoration: InputDecoration(labelText: '초대 코드 입력'),
             ),
             SizedBox(height: 16),
-            TextField(
-              controller: messageController,
-              decoration: InputDecoration(labelText: '신청 메시지'),
-            ),
-            SizedBox(height: 16),
             ElevatedButton(
               onPressed: () async {
                 final groupService = ref.read(groupServiceProvider);
                 try {
-                  // invitationCode로 groupId를 먼저 조회한 후 요청
-                  final joinResult = await groupService.sendJoinRequest(
-                    groupId: '예시 그룹 ID', // 이건 실제 로직에 맞게 수정 필요
+                  final result = await groupService.joinGroup(
+                    invitationCode: codeController.text,
                     userId: widget.userId,
-                    message: messageController.text,
                   );
-                  // 완료 후 처리
                   showDialog(
                     context: context,
                     builder: (_) => AlertDialog(
-                      title: Text('요청 완료'),
-                      content: Text('참여 요청이 전송되었습니다.'),
+                      title: Text('참여 완료'),
+                      content: Text(result['message'] ?? '그룹에 참여했습니다.'),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.of(context).pop(),
@@ -70,7 +60,7 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
                   print(e);
                 }
               },
-              child: Text('참여 요청 보내기'),
+              child: Text('그룹 참여'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -47,26 +47,6 @@ class GroupService {
     }
   }
 
-  // ✅ 그룹 참여 요청 (승인 대기)
-  Future<Map<String, dynamic>> sendJoinRequest({
-    required String groupId,
-    required String userId,
-    required String message,
-  }) async {
-    try {
-      final response = await dio.post(
-        '/api/groups/join-request',
-        data: {
-          'groupId': groupId,
-          'userId': userId,
-          'message': message,
-        },
-      );
-      return response.data;
-    } catch (e) {
-      throw Exception('참여 요청 실패: $e');
-    }
-  }
 
   // ✅ 대기 요청 승인
   Future<Map<String, dynamic>> approveJoinRequest({


### PR DESCRIPTION
## Summary
- allow immediate group association in join API
- use `GroupService.joinGroup` from the join page
- drop old join request method from the service

## Testing
- `npm run lint` *(fails: `next` not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f3b86208324bb97b7531d69fd50