### PR TITLE
Implement group list startup page

### DIFF
--- a/private_board_backend/pages/api/groups/index.ts
+++ b/private_board_backend/pages/api/groups/index.ts
@@ -1,0 +1,30 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { prisma } from '../../../lib/prisma';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const userId = req.query.userId as string | undefined;
+  if (!userId) {
+    return res.status(400).json({ message: 'Missing userId' });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      include: { group: true },
+    });
+
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    const groups = user.group ? [user.group] : [];
+    return res.status(200).json({ groups });
+  } catch (error) {
+    console.error('❌ Fetch user groups error:', error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+}

--- a/private_board_frontend/lib/main.dart
+++ b/private_board_frontend/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'pages/login_page.dart';
-import 'pages/post_list_page.dart';
+import 'pages/group_home_page.dart';
 import 'services/auth_service.dart';
 
 void main() {
@@ -17,11 +17,12 @@ class MyApp extends StatelessWidget {
 
   Future<Widget> getStartPage() async {
     final token = await AuthService.getToken();
+    final userId = await AuthService.getUserId();
     print('앱 시작 토큰 체크: "$token"'); // (디버깅용)
-    if (token == null || token.isEmpty) {
+    if (token == null || token.isEmpty || userId == null) {
       return const LoginPage();
     } else {
-      return const PostListPage(); // TODO: 향후 GroupHomePage로 변경해도 됨
+      return GroupHomePage(userId: userId);
     }
   }
 

--- a/private_board_frontend/lib/pages/group_home_page.dart
+++ b/private_board_frontend/lib/pages/group_home_page.dart
@@ -1,40 +1,91 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/group_provider.dart';
 import 'create_group_page.dart';
 import 'join_group_page.dart';
 
-class GroupHomePage extends StatelessWidget {
+class GroupHomePage extends ConsumerStatefulWidget {
   final String userId;
   const GroupHomePage({required this.userId, Key? key}) : super(key: key);
 
   @override
+  ConsumerState<GroupHomePage> createState() => _GroupHomePageState();
+}
+
+class _GroupHomePageState extends ConsumerState<GroupHomePage> {
+  List<dynamic> groups = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadGroups();
+  }
+
+  Future<void> _loadGroups() async {
+    final service = ref.read(groupServiceProvider);
+    try {
+      final data = await service.getGroups(userId: widget.userId);
+      setState(() {
+        groups = data;
+        _loading = false;
+      });
+    } catch (e) {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('그룹 선택')),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const CreateGroupPage()),
-                );
-              },
-              child: Text('그룹 생성'),
+      appBar: AppBar(title: const Text('그룹 목록')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Expanded(
+                  child: groups.isEmpty
+                      ? const Center(child: Text('참여한 그룹이 없습니다.'))
+                      : ListView.builder(
+                          itemCount: groups.length,
+                          itemBuilder: (context, index) {
+                            final group = groups[index];
+                            return ListTile(
+                              title: Text(group['name'] ?? ''),
+                            );
+                          },
+                        ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (_) => const CreateGroupPage()),
+                          );
+                        },
+                        child: const Text('그룹 생성'),
+                      ),
+                      const SizedBox(width: 12),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => JoinGroupPage(userId: widget.userId)),
+                          );
+                        },
+                        child: const Text('그룹 참여'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => JoinGroupPage(userId: userId)),
-                );
-              },
-              child: Text('그룹 참여'),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -116,4 +116,19 @@ class GroupService {
       throw Exception('대기 요청 조회 실패: $e');
     }
   }
+
+  // 🔹 특정 사용자의 그룹 목록 조회
+  Future<List<dynamic>> getGroups({
+    required String userId,
+  }) async {
+    try {
+      final response = await dio.get(
+        '/api/groups',
+        queryParameters: {'userId': userId},
+      );
+      return List<dynamic>.from(response.data['groups'] ?? []);
+    } catch (e) {
+      throw Exception('그룹 목록 조회 실패: $e');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- show the group list at startup instead of post list
- add API endpoint to return a user's groups
- fetch user's groups in `GroupHomePage`
- provide create and join group actions

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f3c99688324a6c2475a4a8030ea