### PR TITLE
Add basic testing framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: cd private_board_backend && npm ci && npm test
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.5'
+      - run: cd private_board_frontend && flutter pub get && flutter test

--- a/private_board_backend/__tests__/hello.test.ts
+++ b/private_board_backend/__tests__/hello.test.ts
@@ -1,0 +1,11 @@
+import handler from '../pages/api/hello'
+import { createMocks } from 'node-mocks-http'
+
+describe('/api/hello', () => {
+  test('returns John Doe', async () => {
+    const { req, res } = createMocks({ method: 'GET' })
+    await handler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData()).toEqual({ name: 'John Doe' })
+  })
+})

--- a/private_board_backend/jest.config.js
+++ b/private_board_backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.(spec|test).[jt]s'],
+};

--- a/private_board_backend/package.json
+++ b/private_board_backend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",
@@ -25,6 +26,10 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "prisma": "^6.5.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "node-mocks-http": "^1.11.0"
   }
 }

--- a/private_board_frontend/test/login_page_test.dart
+++ b/private_board_frontend/test/login_page_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:private_board_frontend/pages/login_page.dart';
+
+void main() {
+  testWidgets('Login page shows login button', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: LoginPage()));
+
+    expect(find.text('로그인'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- configure Jest in backend and add API test
- add simple Flutter widget test
- run backend and Flutter tests in CI via GitHub Actions

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f3dcbec83249787b3d427436b26