### PR TITLE
Fix join request and group flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,3 +704,14 @@ Authorization: Bearer <your_token_here>
 
 ## ✅ 오늘 한 줄 요약
 > "JWT 기반 인증을 성공적으로 도입하고, 인증된 사용자만 그룹을 생성할 수 있도록 백엔드를 안전하게 구성함."
+
+### Environment configuration
+Frontend services now read the API base URL from a compile-time
+`API_BASE_URL` constant. When building the Flutter app you can override
+this value with:
+
+```
+flutter run --dart-define=API_BASE_URL=https://your-api.com
+```
+
+If omitted, it defaults to `http://localhost:3000`.

--- a/private_board_backend/pages/api/auth/login.ts
+++ b/private_board_backend/pages/api/auth/login.ts
@@ -1,11 +1,10 @@
 // pages/api/auth/login.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 
-const prisma = new PrismaClient()
 const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/private_board_backend/pages/api/auth/register.ts
+++ b/private_board_backend/pages/api/auth/register.ts
@@ -1,10 +1,9 @@
 // pages/api/auth/register.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 
-const prisma = new PrismaClient()
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/private_board_backend/pages/api/groups/join-request.ts
+++ b/private_board_backend/pages/api/groups/join-request.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const { invitationCode } = req.body;
+  const { invitationCode, message } = req.body;
   const userId = req.headers['x-user-id'];
 
   if (!invitationCode || typeof userId !== 'string') {

--- a/private_board_backend/pages/api/me.ts
+++ b/private_board_backend/pages/api/me.ts
@@ -1,10 +1,9 @@
 // pages/api/me.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import { verifyToken } from '@/lib/verifyToken'
 
-const prisma = new PrismaClient()
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {

--- a/private_board_backend/pages/api/posts/[id].ts
+++ b/private_board_backend/pages/api/posts/[id].ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import jwt from 'jsonwebtoken'
 
-const prisma = new PrismaClient()
 const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/private_board_backend/pages/api/posts/[id]/reactions.ts
+++ b/private_board_backend/pages/api/posts/[id]/reactions.ts
@@ -1,12 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import { verifyToken } from '../../../../lib/verifyToken'
 
-const prisma = new PrismaClient()
 
 
 
-export default async function handler(req, res) {
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method Not Allowed' })
   }

--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -1,8 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
+import { prisma } from '@/lib/prisma'
 import jwt from 'jsonwebtoken'
 
-const prisma = new PrismaClient()
 const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/private_board_frontend/lib/config.dart
+++ b/private_board_frontend/lib/config.dart
@@ -1,0 +1,1 @@
+const String apiBaseUrl = String.fromEnvironment('API_BASE_URL', defaultValue: 'http://localhost:3000');

--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
 import '../providers/auth_provider.dart';
+import 'post_list_page.dart';
 
 class CreateGroupPage extends ConsumerWidget {
   const CreateGroupPage({Key? key}) : super(key: key);
@@ -25,14 +26,21 @@ class CreateGroupPage extends ConsumerWidget {
                   token: token,
                 );
 
-                showDialog(
+                await showDialog(
                   context: context,
                   builder: (_) => AlertDialog(
                     content: Text('초대코드: ${result['invitationCode']}'),
                   ),
                 );
+
+                if (context.mounted) {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (_) => const PostListPage()),
+                  );
+                }
               },
-              child: Text('생성'),
+              child: const Text('생성'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/pages/group_home_page.dart
+++ b/private_board_frontend/lib/pages/group_home_page.dart
@@ -41,9 +41,10 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
       appBar: AppBar(title: const Text('그룹 목록')),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : Column(
+          : Row(
               children: [
                 Expanded(
+                  flex: 2,
                   child: groups.isEmpty
                       ? const Center(child: Text('참여한 그룹이 없습니다.'))
                       : ListView.builder(
@@ -56,9 +57,8 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
                           },
                         ),
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 16.0),
-                  child: Row(
+                Expanded(
+                  child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       ElevatedButton(
@@ -70,7 +70,7 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
                         },
                         child: const Text('그룹 생성'),
                       ),
-                      const SizedBox(width: 12),
+                      const SizedBox(height: 12),
                       ElevatedButton(
                         onPressed: () {
                           Navigator.push(

--- a/private_board_frontend/lib/pages/join_group_page.dart
+++ b/private_board_frontend/lib/pages/join_group_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
+import 'post_list_page.dart';
 
 class JoinGroupPage extends ConsumerStatefulWidget {
   final String userId;
@@ -43,7 +44,7 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
                     invitationCode: codeController.text,
                     userId: widget.userId,
                   );
-                  showDialog(
+                  await showDialog(
                     context: context,
                     builder: (_) => AlertDialog(
                       title: Text('참여 완료'),
@@ -56,6 +57,12 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
                       ],
                     ),
                   );
+                  if (context.mounted) {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (_) => const PostListPage()),
+                    );
+                  }
                 } catch (e) {
                   print(e);
                 }

--- a/private_board_frontend/lib/providers/dio_provider.dart
+++ b/private_board_frontend/lib/providers/dio_provider.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../config.dart';
 
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
     BaseOptions(
-      baseUrl: 'https://your-api.com/api', // ✅ 여기에 네 API 주소
+      baseUrl: apiBaseUrl,
       connectTimeout: const Duration(seconds: 5),
       receiveTimeout: const Duration(seconds: 5),
       headers: {

--- a/private_board_frontend/lib/services/auth_service.dart
+++ b/private_board_frontend/lib/services/auth_service.dart
@@ -1,8 +1,9 @@
 import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../config.dart';
 
 class AuthService {
-  static const _baseUrl = 'http://localhost:3000';
+  static const _baseUrl = apiBaseUrl;
 
   /// 🔐 회원가입
   static Future<String> register(String email, String password) async {

--- a/private_board_frontend/lib/services/post_api.dart
+++ b/private_board_frontend/lib/services/post_api.dart
@@ -1,9 +1,11 @@
 import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart'; // Navigator 등 context 필요 시
+import '../config.dart';
+import '../models/post.dart';
 
 class PostApi {
-  static const _baseUrl = 'http://localhost:3000';
+  static const _baseUrl = apiBaseUrl;
   static final Dio _dio = Dio();
 
   // 토큰 불러오기
@@ -58,6 +60,11 @@ class PostApi {
       print('❌ 글 등록 요청 실패: $e');
       return false;
     }
+  }
+
+  /// WritePage 호환용 메서드
+  static Future<bool> createPost(Post post) {
+    return create(post.title, post.content);
   }
 
   /// 게시글 수정


### PR DESCRIPTION
## Summary
- use shared prisma client across endpoints
- add message field to join request handler
- expose API base URL via new config
- align PostApi with WritePage
- navigate to posts after creating or joining a group
- update group layout

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638c27b5788324a6721c76029cef4b