### PR TITLE
Fix group creation API base URL

### DIFF
--- a/private_board_frontend/lib/providers/dio_provider.dart
+++ b/private_board_frontend/lib/providers/dio_provider.dart
@@ -4,10 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
     BaseOptions(
-      baseUrl: 'https://your-api.com/api', // ✅ 여기에 네 API 주소
+      // Backend base URL
+      // 로컬 개발 시 Next.js API 서버 주소를 사용합니다.
+      // API 경로는 서비스에서 '/api/...' 형태로 호출하므로
+      // 여기서는 서버 루트 URL만 지정합니다.
+      baseUrl: 'http://localhost:3000',
       connectTimeout: const Duration(seconds: 5),
       receiveTimeout: const Duration(seconds: 5),
-      headers: {
+      headers: const {
         'Content-Type': 'application/json',
       },
     ),


### PR DESCRIPTION
## Summary
- correct dio provider base URL to allow group creation requests to reach backend

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863c255610883249c75a9cfcedf43f6