### PR TITLE
Add group login ID with duplicate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,9 +478,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
 - API: `POST /api/groups/create`
 - 요청 시:
-  - `name` 필수
-  - `x-user-id` 헤더 필요
+  - `name`, `loginId`, `password` 필수
+  - `Authorization` 헤더에 JWT 필요
 - 처리 로직:
+  - `loginId` 중복 여부 확인 후 해시된 `password` 저장
   - 초대코드 자동 생성 (nanoid)
   - 생성자는 자동으로 `ADMIN` 역할로 그룹에 소속됨
 - 응답:

--- a/private_board_backend/pages/api/groups/check-id.ts
+++ b/private_board_backend/pages/api/groups/check-id.ts
@@ -1,0 +1,21 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const loginId = req.query.loginId
+  if (!loginId || typeof loginId !== 'string') {
+    return res.status(400).json({ message: 'Missing loginId' })
+  }
+
+  try {
+    const existing = await prisma.group.findUnique({ where: { loginId } })
+    return res.status(200).json({ available: !existing })
+  } catch (error) {
+    console.error('check-id error', error)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+}

--- a/private_board_backend/pages/api/groups/create.ts
+++ b/private_board_backend/pages/api/groups/create.ts
@@ -1,7 +1,8 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
-import { nanoid } from 'nanoid';
-import { verifyToken } from '../../../lib/auth'; // 추가
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+import { nanoid } from 'nanoid'
+import bcrypt from 'bcryptjs'
+import { verifyToken } from '../../../lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -13,17 +14,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const userId = decoded.sub as string;
 
-  const { name } = req.body;
-  if (!name || !userId) {
-    return res.status(400).json({ message: 'Missing group name or user ID' });
+  const { name, loginId, password } = req.body
+  if (!name || !loginId || !password || !userId) {
+    return res.status(400).json({ message: 'Missing parameters' })
+  }
+
+  const existing = await prisma.group.findUnique({ where: { loginId } })
+  if (existing) {
+    return res.status(409).json({ message: 'Duplicate groupId' })
   }
 
   try {
     const invitationCode = nanoid(6).toUpperCase();
+    const hashedPassword = await bcrypt.hash(password, 10)
 
     const group = await prisma.group.create({
       data: {
         name,
+        loginId,
+        password: hashedPassword,
         invitationCode,
         hasAdmin: true,
       },

--- a/private_board_backend/prisma/migrations/20250701000000_add_group_login/migration.sql
+++ b/private_board_backend/prisma/migrations/20250701000000_add_group_login/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN "loginId" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "Group" ADD COLUMN "password" TEXT NOT NULL DEFAULT '';
+CREATE UNIQUE INDEX "Group_loginId_key" ON "Group"("loginId");
+ALTER TABLE "Group" ALTER COLUMN "loginId" DROP DEFAULT;
+ALTER TABLE "Group" ALTER COLUMN "password" DROP DEFAULT;

--- a/private_board_backend/prisma/schema.prisma
+++ b/private_board_backend/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
 
 model Group {
   id             String   @id @default(uuid())
+  loginId        String   @unique
+  password       String
   name           String
   invitationCode String   @unique
   hasAdmin       Boolean  @default(false)

--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -9,7 +9,10 @@ class CreateGroupPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nameController = TextEditingController();
+    final idController = TextEditingController();
+    final pwController = TextEditingController();
     final token = ref.watch(tokenProvider);
+    bool idAvailable = false;
 
     return Scaffold(
       appBar: AppBar(title: Text('그룹 생성')),
@@ -17,22 +20,65 @@ class CreateGroupPage extends ConsumerWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            TextField(controller: nameController, decoration: InputDecoration(labelText: '그룹 이름')),
+            TextField(controller: nameController, decoration: const InputDecoration(labelText: '그룹 이름')),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: idController,
+                    decoration: const InputDecoration(labelText: '그룹 ID'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () async {
+                    final available = await ref.read(groupServiceProvider).checkGroupId(idController.text);
+                    idAvailable = available;
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(available ? '사용 가능한 ID입니다.' : '이미 존재하는 ID입니다.')),
+                      );
+                    }
+                  },
+                  child: const Text('중복 확인'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: pwController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: '그룹 비밀번호'),
+            ),
             ElevatedButton(
               onPressed: () async {
                 final result = await ref.read(groupServiceProvider).createGroup(
                   name: nameController.text,
+                  groupId: idController.text,
+                  password: pwController.text,
                   token: token,
                 );
 
-                showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    content: Text('초대코드: ${result['invitationCode']}'),
-                  ),
-                );
+                if (result['status'] == 'conflict') {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('이미 존재하는 그룹 ID입니다.')),
+                    );
+                  }
+                  return;
+                }
+
+                if (context.mounted) {
+                  showDialog(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      content: Text('초대코드: ${result['invitationCode']}'),
+                    ),
+                  );
+                }
               },
-              child: Text('생성'),
+              child: const Text('생성'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/providers/dio_provider.dart
+++ b/private_board_frontend/lib/providers/dio_provider.dart
@@ -4,10 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
     BaseOptions(
-      baseUrl: 'https://your-api.com/api', // ✅ 여기에 네 API 주소
+      // Backend base URL
+      // 로컬 개발 시 Next.js API 서버 주소를 사용합니다.
+      // API 경로는 서비스에서 '/api/...' 형태로 호출하므로
+      // 여기서는 서버 루트 URL만 지정합니다.
+      baseUrl: 'http://localhost:3000',
       connectTimeout: const Duration(seconds: 5),
       receiveTimeout: const Duration(seconds: 5),
-      headers: {
+      headers: const {
         'Content-Type': 'application/json',
       },
     ),

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -8,6 +8,8 @@ class GroupService {
   // 🔹 그룹 생성 (JWT 토큰 기반 인증)
   Future<Map<String, dynamic>> createGroup({
     required String name,
+    required String groupId,
+    required String password,
     required String token,
   }) async {
     try {
@@ -15,6 +17,8 @@ class GroupService {
         '/api/groups/create',
         data: {
           'name': name,
+          'loginId': groupId,
+          'password': password,
         },
         options: Options(
           headers: {
@@ -22,9 +26,28 @@ class GroupService {
           },
         ),
       );
-      return response.data;
-    } catch (e) {
+
+      return {
+        'status': response.statusCode == 201 ? 'success' : 'error',
+        ...response.data,
+      };
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 409) {
+        return {'status': 'conflict'};
+      }
       throw Exception('그룹 생성 실패: $e');
+    }
+  }
+
+  Future<bool> checkGroupId(String groupId) async {
+    try {
+      final response = await dio.get(
+        '/api/groups/check-id',
+        queryParameters: {'loginId': groupId},
+      );
+      return response.data['available'] as bool;
+    } catch (e) {
+      throw Exception('중복 확인 실패: $e');
     }
   }
 


### PR DESCRIPTION
## Summary
- extend Group schema with loginId and password
- return conflict on duplicate groupId during group creation
- add `/api/groups/check-id` endpoint
- update Flutter GroupService and CreateGroupPage with ID/password fields
- document new fields in README

## Testing
- `npm test` *(fails: jest not found)*
- `flutter test` *(fails: flutter not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6863c255610883249c75a9cfcedf43f6