### PR TITLE
Add welcome page and improve group creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,9 +478,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
 - API: `POST /api/groups/create`
 - 요청 시:
-  - `name` 필수
-  - `x-user-id` 헤더 필요
+  - `name`, `loginId`, `password` 필수
+  - `Authorization` 헤더에 JWT 필요
 - 처리 로직:
+  - `loginId` 중복 여부 확인 후 해시된 `password` 저장
   - 초대코드 자동 생성 (nanoid)
   - 생성자는 자동으로 `ADMIN` 역할로 그룹에 소속됨
 - 응답:

--- a/private_board_backend/pages/api/groups/check-id.ts
+++ b/private_board_backend/pages/api/groups/check-id.ts
@@ -1,0 +1,21 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const loginId = req.query.loginId
+  if (!loginId || typeof loginId !== 'string') {
+    return res.status(400).json({ message: 'Missing loginId' })
+  }
+
+  try {
+    const existing = await prisma.group.findUnique({ where: { loginId } })
+    return res.status(200).json({ available: !existing })
+  } catch (error) {
+    console.error('check-id error', error)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+}

--- a/private_board_backend/pages/api/groups/create.ts
+++ b/private_board_backend/pages/api/groups/create.ts
@@ -1,7 +1,8 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import { prisma } from '../../../lib/prisma';
-import { nanoid } from 'nanoid';
-import { verifyToken } from '../../../lib/auth'; // 추가
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+import { nanoid } from 'nanoid'
+import bcrypt from 'bcryptjs'
+import { verifyToken } from '../../../lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -13,17 +14,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const userId = decoded.sub as string;
 
-  const { name } = req.body;
-  if (!name || !userId) {
-    return res.status(400).json({ message: 'Missing group name or user ID' });
+  const { name, loginId, password } = req.body
+  if (!name || !loginId || !password || !userId) {
+    return res.status(400).json({ message: 'Missing parameters' })
+  }
+
+  const existing = await prisma.group.findUnique({ where: { loginId } })
+  if (existing) {
+    return res.status(409).json({ message: 'Duplicate groupId' })
   }
 
   try {
     const invitationCode = nanoid(6).toUpperCase();
+    const hashedPassword = await bcrypt.hash(password, 10)
 
     const group = await prisma.group.create({
       data: {
         name,
+        loginId,
+        password: hashedPassword,
         invitationCode,
         hasAdmin: true,
       },

--- a/private_board_backend/pages/api/groups/login.ts
+++ b/private_board_backend/pages/api/groups/login.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+import bcrypt from 'bcryptjs'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const { loginId, password } = req.body
+  const userId = req.headers['x-user-id']
+
+  if (!loginId || !password || typeof userId !== 'string') {
+    return res.status(400).json({ message: 'Missing credentials or userId' })
+  }
+
+  try {
+    const group = await prisma.group.findUnique({ where: { loginId } })
+    if (!group) {
+      return res.status(404).json({ message: 'Group not found' })
+    }
+
+    const match = await bcrypt.compare(password, group.password)
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid password' })
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { groupId: group.id },
+    })
+
+    return res.status(200).json({ message: 'Joined group', groupName: group.name })
+  } catch (error) {
+    console.error('group login error', error)
+    return res.status(500).json({ message: 'Internal server error' })
+  }
+}

--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -22,8 +22,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: 'Invalid token' })
     }
 
-    const { title, content } = req.body
-    if (!title || !content) return res.status(400).json({ message: 'Missing fields' })
+  const { title, content, groupId } = req.body
+    if (!title || !content || !groupId) {
+      return res.status(400).json({ message: 'Missing fields' })
+    }
 
     try {
       const post = await prisma.post.create({
@@ -31,6 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           title,
           content,
           authorId: userId,
+          groupId,
         }
       })
 
@@ -42,13 +45,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // ✅ GET /api/posts
   if (req.method === 'GET') {
+    const { groupId } = req.query
     try {
       const posts = await prisma.post.findMany({
+        where: groupId ? { groupId: String(groupId) } : undefined,
         orderBy: { createdAt: 'desc' },
         include: {
           author: {
             select: {
-              id: true,       // ✅ 추가!
+              id: true,
               email: true,
             },
           },

--- a/private_board_backend/prisma/migrations/20250701000000_add_group_login/migration.sql
+++ b/private_board_backend/prisma/migrations/20250701000000_add_group_login/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN "loginId" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "Group" ADD COLUMN "password" TEXT NOT NULL DEFAULT '';
+CREATE UNIQUE INDEX "Group_loginId_key" ON "Group"("loginId");
+ALTER TABLE "Group" ALTER COLUMN "loginId" DROP DEFAULT;
+ALTER TABLE "Group" ALTER COLUMN "password" DROP DEFAULT;

--- a/private_board_backend/prisma/schema.prisma
+++ b/private_board_backend/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
 
 model Group {
   id             String   @id @default(uuid())
+  loginId        String   @unique
+  password       String
   name           String
   invitationCode String   @unique
   hasAdmin       Boolean  @default(false)

--- a/private_board_frontend/lib/main.dart
+++ b/private_board_frontend/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'pages/login_page.dart';
 import 'pages/group_home_page.dart';
+import 'pages/welcome_page.dart';
 import 'services/auth_service.dart';
 
 void main() {
@@ -18,11 +19,12 @@ class MyApp extends StatelessWidget {
   Future<Widget> getStartPage() async {
     final token = await AuthService.getToken();
     final userId = await AuthService.getUserId();
+    final email = await AuthService.getUserEmail();
     print('앱 시작 토큰 체크: "$token"'); // (디버깅용)
-    if (token == null || token.isEmpty || userId == null) {
+    if (token == null || token.isEmpty || userId == null || email == null) {
       return const LoginPage();
     } else {
-      return GroupHomePage(userId: userId);
+      return WelcomePage(userId: userId, email: email);
     }
   }
 

--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -2,37 +2,134 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
 import '../providers/auth_provider.dart';
+import 'post_list_page.dart';
 
-class CreateGroupPage extends ConsumerWidget {
+class CreateGroupPage extends ConsumerStatefulWidget {
   const CreateGroupPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final nameController = TextEditingController();
+  ConsumerState<CreateGroupPage> createState() => _CreateGroupPageState();
+}
+
+class _CreateGroupPageState extends ConsumerState<CreateGroupPage> {
+  final nameController = TextEditingController();
+  final idController = TextEditingController();
+  final pwController = TextEditingController();
+  bool? idAvailable;
+  bool idChecked = false;
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    idController.dispose();
+    pwController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final token = ref.watch(tokenProvider);
 
     return Scaffold(
-      appBar: AppBar(title: Text('그룹 생성')),
+      appBar: AppBar(
+        title: const Text('그룹 생성'),
+        leading: Navigator.canPop(context) ? const BackButton() : null,
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
-            TextField(controller: nameController, decoration: InputDecoration(labelText: '그룹 이름')),
+            TextField(controller: nameController, decoration: const InputDecoration(labelText: '그룹 이름')),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: idController,
+                    decoration: const InputDecoration(labelText: '그룹 ID'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () async {
+                    final available = await ref.read(groupServiceProvider).checkGroupId(idController.text);
+                    setState(() {
+                      idChecked = true;
+                      idAvailable = available;
+                    });
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context)
+                        ..hideCurrentMaterialBanner()
+                        ..showMaterialBanner(
+                          MaterialBanner(
+                            content: Text(available ? '사용 가능한 ID입니다.' : '이미 존재하는 ID입니다.'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => ScaffoldMessenger.of(context).hideCurrentMaterialBanner(),
+                                child: const Text('닫기'),
+                              )
+                            ],
+                          ),
+                        );
+                    }
+                  },
+                  child: const Text('중복 확인'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: pwController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: '그룹 비밀번호'),
+            ),
             ElevatedButton(
               onPressed: () async {
+                if (!idChecked || idAvailable != true) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('ID 중복 확인을 완료해주세요.')),
+                  );
+                  return;
+                }
+
                 final result = await ref.read(groupServiceProvider).createGroup(
                   name: nameController.text,
+                  groupId: idController.text,
+                  password: pwController.text,
                   token: token,
                 );
 
-                showDialog(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    content: Text('초대코드: ${result['invitationCode']}'),
-                  ),
-                );
+                if (result['status'] == 'conflict') {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('이미 존재하는 그룹 ID입니다.')),
+                    );
+                  }
+                  return;
+                }
+
+                if (context.mounted) {
+                  await showDialog(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      content: Text('초대코드: ${result['invitationCode']}'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: const Text('확인'),
+                        )
+                      ],
+                    ),
+                  );
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PostListPage(groupId: result['groupId']),
+                    ),
+                  );
+                }
               },
-              child: Text('생성'),
+              child: const Text('생성'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/pages/create_post_page.dart
+++ b/private_board_frontend/lib/pages/create_post_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import '../services/post_api.dart';
 
 class CreatePostPage extends StatefulWidget {
-  const CreatePostPage({super.key});
+  final String groupId;
+  const CreatePostPage({super.key, required this.groupId});
 
   @override
   State<CreatePostPage> createState() => _CreatePostPageState();
@@ -25,7 +26,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
     }
 
     setState(() => isSubmitting = true);
-    final success = await PostApi.create(title, content);
+    final success = await PostApi.create(title, content, widget.groupId);
     setState(() => isSubmitting = false);
 
     if (success && mounted) {
@@ -46,6 +47,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
         title: const Text('✍️ 글쓰기'),
         backgroundColor: Colors.orange[200],
         centerTitle: true,
+        leading: Navigator.canPop(context) ? const BackButton() : null,
       ),
       body: Padding(
         padding: const EdgeInsets.all(20),

--- a/private_board_frontend/lib/pages/group_home_page.dart
+++ b/private_board_frontend/lib/pages/group_home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
 import 'create_group_page.dart';
 import 'join_group_page.dart';
+import 'post_list_page.dart';
 
 class GroupHomePage extends ConsumerStatefulWidget {
   final String userId;
@@ -38,7 +39,10 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('그룹 목록')),
+      appBar: AppBar(
+        title: const Text('그룹 목록'),
+        leading: Navigator.canPop(context) ? const BackButton() : null,
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : Column(
@@ -52,6 +56,14 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
                             final group = groups[index];
                             return ListTile(
                               title: Text(group['name'] ?? ''),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => PostListPage(groupId: group['id']),
+                                  ),
+                                );
+                              },
                             );
                           },
                         ),

--- a/private_board_frontend/lib/pages/join_group_page.dart
+++ b/private_board_frontend/lib/pages/join_group_page.dart
@@ -13,11 +13,13 @@ class JoinGroupPage extends ConsumerStatefulWidget {
 
 class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
 
-  final codeController = TextEditingController();
+  final idController = TextEditingController();
+  final pwController = TextEditingController();
 
   @override
   void dispose() {
-    codeController.dispose();
+    idController.dispose();
+    pwController.dispose();
     super.dispose();
   }
 
@@ -25,42 +27,54 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
   Widget build(BuildContext context) {
     // 예시 UI 코드
     return Scaffold(
-      appBar: AppBar(title: Text('그룹 참여')),
+      appBar: AppBar(
+        title: const Text('그룹 참여'),
+        leading: Navigator.canPop(context) ? const BackButton() : null,
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
             TextField(
-              controller: codeController,
-              decoration: InputDecoration(labelText: '초대 코드 입력'),
+              controller: idController,
+              decoration: const InputDecoration(labelText: '그룹 ID'),
             ),
-            SizedBox(height: 16),
+            const SizedBox(height: 12),
+            TextField(
+              controller: pwController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: '비밀번호'),
+            ),
+            const SizedBox(height: 16),
             ElevatedButton(
               onPressed: () async {
                 final groupService = ref.read(groupServiceProvider);
                 try {
-                  final result = await groupService.joinGroup(
-                    invitationCode: codeController.text,
+                  final result = await groupService.joinGroupByCredential(
+                    groupId: idController.text,
+                    password: pwController.text,
                     userId: widget.userId,
                   );
-                  showDialog(
-                    context: context,
-                    builder: (_) => AlertDialog(
-                      title: Text('참여 완료'),
-                      content: Text(result['message'] ?? '그룹에 참여했습니다.'),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text('확인'),
-                        ),
-                      ],
-                    ),
-                  );
+                  if (context.mounted) {
+                    showDialog(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        title: const Text('참여 완료'),
+                        content: Text(result['message'] ?? '그룹에 참여했습니다.'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: const Text('확인'),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
                 } catch (e) {
                   print(e);
                 }
               },
-              child: Text('그룹 참여'),
+              child: const Text('그룹 참여'),
             ),
           ],
         ),

--- a/private_board_frontend/lib/pages/login_page.dart
+++ b/private_board_frontend/lib/pages/login_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/auth_service.dart';
-import '../pages/group_home_page.dart';
+import 'welcome_page.dart';
 import '../providers/auth_provider.dart';
 import 'register_page.dart';
 
@@ -25,15 +25,19 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     if (response != null && mounted) {
       final token = response['token'];
       final userId = response['user']['id'];
+      final email = response['user']['email'];
 
       // 전역 상태에 저장
       ref.read(tokenProvider.notifier).state = token;
       ref.read(userIdProvider.notifier).state = userId;
+      ref.read(userEmailProvider.notifier).state = email;
 
       // 그룹 선택 페이지로 이동
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (_) => GroupHomePage(userId: userId)),
+        MaterialPageRoute(
+          builder: (_) => WelcomePage(userId: userId, email: email),
+        ),
       );
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -45,7 +49,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('🔐 로그인')),
+      appBar: AppBar(
+        title: const Text('🔐 로그인'),
+        leading: Navigator.canPop(context) ? const BackButton() : null,
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/private_board_frontend/lib/pages/post_detail_page.dart
+++ b/private_board_frontend/lib/pages/post_detail_page.dart
@@ -146,6 +146,7 @@ class _PostDetailPageState extends State<PostDetailPage> {
         title: const Text('📖 게시글 상세'),
         backgroundColor: Colors.orange[200],
         centerTitle: true,
+        leading: Navigator.canPop(context) ? const BackButton() : null,
         actions: isOwner
             ? [
           IconButton(

--- a/private_board_frontend/lib/pages/post_list_page.dart
+++ b/private_board_frontend/lib/pages/post_list_page.dart
@@ -6,7 +6,8 @@ import '../services/auth_service.dart';
 import '../pages/login_page.dart';
 
 class PostListPage extends StatefulWidget {
-  const PostListPage({super.key});
+  final String groupId;
+  const PostListPage({super.key, required this.groupId});
 
   @override
   State<PostListPage> createState() => _PostListPageState();
@@ -40,7 +41,7 @@ class _PostListPageState extends State<PostListPage> {
 
   Future<void> loadPosts() async {
     print('[PostListPage] loadPosts 호출');
-    final data = await PostApi.fetchPosts();
+    final data = await PostApi.fetchPosts(groupId: widget.groupId);
     print('[PostListPage] 받아온 글 개수: ${data.length}');
     setState(() {
       posts = data;
@@ -64,6 +65,7 @@ class _PostListPageState extends State<PostListPage> {
       backgroundColor: const Color(0xFFFFFBF2),
       appBar: AppBar(
         title: const Text('🌿 따뜻한 하루'),
+        leading: Navigator.canPop(context) ? const BackButton() : null,
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),
@@ -123,7 +125,7 @@ class _PostListPageState extends State<PostListPage> {
         onPressed: () async {
           final result = await Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const CreatePostPage()),
+            MaterialPageRoute(builder: (_) => CreatePostPage(groupId: widget.groupId)),
           );
           if (result == true) {
             await loadPosts(); // 글쓰기 성공 시 목록 새로고침

--- a/private_board_frontend/lib/pages/register_page.dart
+++ b/private_board_frontend/lib/pages/register_page.dart
@@ -50,6 +50,7 @@ class _RegisterPageState extends State<RegisterPage> {
         backgroundColor: Colors.orange[200],
         title: const Text('🧡 따뜻한 회원가입'),
         centerTitle: true,
+        leading: Navigator.canPop(context) ? const BackButton() : null,
       ),
       body: Padding(
         padding: const EdgeInsets.all(24),

--- a/private_board_frontend/lib/pages/welcome_page.dart
+++ b/private_board_frontend/lib/pages/welcome_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/auth_provider.dart';
+import '../services/auth_service.dart';
+import 'group_home_page.dart';
+import 'login_page.dart';
+
+class WelcomePage extends ConsumerWidget {
+  final String userId;
+  final String email;
+  const WelcomePage({Key? key, required this.userId, required this.email}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: const Text('환영합니다'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              '$email 님 안녕하세요!',
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => GroupHomePage(userId: userId)),
+                );
+              },
+              child: const Text('그룹 목록 보기'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () async {
+                await AuthService.logout();
+                ref.read(tokenProvider.notifier).state = '';
+                ref.read(userIdProvider.notifier).state = '';
+                ref.read(userEmailProvider.notifier).state = '';
+                if (context.mounted) {
+                  Navigator.pushAndRemoveUntil(
+                    context,
+                    MaterialPageRoute(builder: (_) => const LoginPage()),
+                    (route) => false,
+                  );
+                }
+              },
+              child: const Text('로그아웃'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/private_board_frontend/lib/providers/auth_provider.dart
+++ b/private_board_frontend/lib/providers/auth_provider.dart
@@ -2,3 +2,4 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final tokenProvider = StateProvider<String>((ref) => '');
 final userIdProvider = StateProvider<String>((ref) => '');
+final userEmailProvider = StateProvider<String>((ref) => '');

--- a/private_board_frontend/lib/providers/dio_provider.dart
+++ b/private_board_frontend/lib/providers/dio_provider.dart
@@ -4,10 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
     BaseOptions(
-      baseUrl: 'https://your-api.com/api', // ✅ 여기에 네 API 주소
+      // Backend base URL
+      // 로컬 개발 시 Next.js API 서버 주소를 사용합니다.
+      // API 경로는 서비스에서 '/api/...' 형태로 호출하므로
+      // 여기서는 서버 루트 URL만 지정합니다.
+      baseUrl: 'http://localhost:3000',
       connectTimeout: const Duration(seconds: 5),
       receiveTimeout: const Duration(seconds: 5),
-      headers: {
+      headers: const {
         'Content-Type': 'application/json',
       },
     ),

--- a/private_board_frontend/lib/services/auth_service.dart
+++ b/private_board_frontend/lib/services/auth_service.dart
@@ -43,11 +43,13 @@ class AuthService {
 
       final token = response.data['accessToken'] ?? response.data['token'];
       final userId = response.data['user']?['id'];
+      final userEmail = response.data['user']?['email'];
 
-      if (token != null && userId != null) {
+      if (token != null && userId != null && userEmail != null) {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('accessToken', token);
         await prefs.setString('userId', userId);
+        await prefs.setString('userEmail', userEmail);
         return response.data; // 전체 response 반환
       }
     } catch (e) {
@@ -68,11 +70,18 @@ class AuthService {
     return prefs.getString('userId');
   }
 
+  /// 현재 저장된 유저 이메일 가져오기
+  static Future<String?> getUserEmail() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('userEmail');
+  }
+
   /// 로그아웃 (토큰 + 유저ID 삭제)
   static Future<void> logout() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('accessToken');
     await prefs.remove('userId');
+    await prefs.remove('userEmail');
   }
 
   /// (선택) 토큰 유효성 검사 예시 (추가로 활용 가능)

--- a/private_board_frontend/lib/services/group_service.dart
+++ b/private_board_frontend/lib/services/group_service.dart
@@ -8,6 +8,8 @@ class GroupService {
   // 🔹 그룹 생성 (JWT 토큰 기반 인증)
   Future<Map<String, dynamic>> createGroup({
     required String name,
+    required String groupId,
+    required String password,
     required String token,
   }) async {
     try {
@@ -15,6 +17,8 @@ class GroupService {
         '/api/groups/create',
         data: {
           'name': name,
+          'loginId': groupId,
+          'password': password,
         },
         options: Options(
           headers: {
@@ -22,9 +26,28 @@ class GroupService {
           },
         ),
       );
-      return response.data;
-    } catch (e) {
+
+      return {
+        'status': response.statusCode == 201 ? 'success' : 'error',
+        ...response.data,
+      };
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 409) {
+        return {'status': 'conflict'};
+      }
       throw Exception('그룹 생성 실패: $e');
+    }
+  }
+
+  Future<bool> checkGroupId(String groupId) async {
+    try {
+      final response = await dio.get(
+        '/api/groups/check-id',
+        queryParameters: {'loginId': groupId},
+      );
+      return response.data['available'] as bool;
+    } catch (e) {
+      throw Exception('중복 확인 실패: $e');
     }
   }
 
@@ -41,6 +64,27 @@ class GroupService {
       );
       return response.data;
     } catch (e) {
+      throw Exception('그룹 참여 실패: $e');
+    }
+  }
+
+  /// 로그인 ID와 비밀번호로 그룹 참여
+  Future<Map<String, dynamic>> joinGroupByCredential({
+    required String groupId,
+    required String password,
+    required String userId,
+  }) async {
+    try {
+      final response = await dio.post(
+        '/api/groups/login',
+        data: {'loginId': groupId, 'password': password},
+        options: Options(headers: {'x-user-id': userId}),
+      );
+      return response.data as Map<String, dynamic>;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        return {'message': 'Invalid password'};
+      }
       throw Exception('그룹 참여 실패: $e');
     }
   }

--- a/private_board_frontend/lib/services/post_api.dart
+++ b/private_board_frontend/lib/services/post_api.dart
@@ -13,7 +13,7 @@ class PostApi {
   }
 
   /// 🔍 게시글 목록 조회 (토큰 인증 포함 + 상세 로그)
-  static Future<List<dynamic>> fetchPosts() async {
+  static Future<List<dynamic>> fetchPosts({String? groupId}) async {
     final token = await _getToken();
     print('글목록 fetchPosts() 시 토큰: $token');
 
@@ -21,6 +21,7 @@ class PostApi {
     try {
       final response = await _dio.get(
         url,
+        queryParameters: groupId != null ? {'groupId': groupId} : null,
         options: Options(
           headers: {
             if (token != null) 'Authorization': 'Bearer $token',
@@ -39,7 +40,7 @@ class PostApi {
   }
 
   /// ✍️ 게시글 등록
-  static Future<bool> create(String title, String content) async {
+  static Future<bool> create(String title, String content, String groupId) async {
     final token = await _getToken();
     if (token == null) {
       print('❌ 로그인 토큰 없음: 글 작성 불가');
@@ -48,7 +49,7 @@ class PostApi {
     try {
       final response = await _dio.post(
         '$_baseUrl/api/posts',
-        data: {'title': title, 'content': content},
+        data: {'title': title, 'content': content, 'groupId': groupId},
         options: Options(
           headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
         ),


### PR DESCRIPTION
## Summary
- show greeting and logout screen after login
- store user email for reuse
- enforce group ID duplication check before creation
- navigate back from group list to welcome screen

## Testing
- `npm test` *(fails: Missing script)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863c255610883249c75a9cfcedf43f6