### PR TITLE
Fix join request message parameter

### DIFF
--- a/private_board_backend/pages/api/groups/join-request.ts
+++ b/private_board_backend/pages/api/groups/join-request.ts
@@ -6,7 +6,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const { invitationCode } = req.body;
+  const { invitationCode, message } = req.body;
   const userId = req.headers['x-user-id'];
 
   if (!invitationCode || typeof userId !== 'string') {


### PR DESCRIPTION
## Summary
- fix join-request API to include `message` field from request body

## Testing
- `npm test` *(fails: jest not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874dedd67388324a5b9871f23fa13b4