### PR TITLE
feat: scaffold prisma and nest backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME?schema=public
+JWT_SECRET=replace_me
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+# Node
+node_modules/
+dist/

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,29 @@
 {
+  "name": "private-board-backend",
+  "version": "1.0.0",
+  "scripts": {
+    "prisma:gen": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:deploy": "prisma migrate deploy",
+    "start": "cross-env PORT=${PORT:-3000} node dist/main.js",
+    "start:dev": "cross-env PORT=${PORT:-3000} nest start --watch",
+    "seed": "ts-node prisma/seed.ts"
+  },
   "dependencies": {
-    "jsonwebtoken": "^9.0.2"
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@prisma/client": "^5.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "cross-env": "^7.0.3",
+    "jsonwebtoken": "^9.0.2",
+    "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0",
+    "prisma": "^5.0.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,158 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id           String   @id @default(uuid())
+  email        String   @unique
+  displayName  String?
+  createdAt    DateTime @default(now())
+
+  groups       Group[]       @relation("UserGroups")
+  memberships  GroupMember[]
+  posts        Post[]
+  comments     Comment[]
+  postReacts   PostReaction[]
+  commentReacts CommentReaction[]
+
+  @@map("user")
+}
+
+model Group {
+  id           String   @id @default(uuid())
+  groupName    String
+  groupId      String   @unique
+  passwordHash String?
+  createdAt    DateTime @default(now())
+
+  createdById  String
+  createdBy    User @relation(
+    name: "UserGroups",
+    fields: [createdById],
+    references: [id],
+    onUpdate: Cascade,
+    onDelete: Restrict
+  )
+
+  members GroupMember[]
+  posts   Post[]
+
+  @@map("group")
+}
+
+model GroupMember {
+  id        String   @id @default(uuid())
+  groupId   String
+  userId    String
+  role      Role     @default(MEMBER)
+  status    Status   @default(ACTIVE)
+  joinedAt  DateTime @default(now())
+
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+
+  @@unique([groupId, userId])
+  @@map("group_member")
+}
+
+model Post {
+  id        String   @id @default(uuid())
+  groupId   String
+  authorId  String
+  title     String
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  group     Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  author    User  @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  reactions PostReaction[]
+  comments  Comment[]
+
+  @@map("post")
+}
+
+model Comment {
+  id        String   @id @default(uuid())
+  postId    String
+  authorId  String
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  post   Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+  author User @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  reactions CommentReaction[]
+
+  @@map("comment")
+}
+
+model PostReaction {
+  id        String   @id @default(uuid())
+  postId    String
+  userId    String
+  type      ReactionType
+  createdAt DateTime @default(now())
+
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([postId, userId, type])
+  @@map("post_reaction")
+}
+
+model CommentReaction {
+  id        String   @id @default(uuid())
+  commentId String
+  userId    String
+  type      ReactionType
+  createdAt DateTime @default(now())
+
+  comment Comment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([commentId, userId, type])
+  @@map("comment_reaction")
+}
+
+model InviteCode {
+  id         String   @id @default(uuid())
+  groupId    String
+  code       String   @unique
+  expiresAt  DateTime?
+  maxUses    Int?
+  useCount   Int      @default(0)
+  createdAt  DateTime @default(now())
+  createdById String
+
+  group     Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  createdBy User  @relation(fields: [createdById], references: [id], onDelete: Restrict)
+
+  @@map("invite_code")
+}
+
+enum Role {
+  ADMIN
+  MEMBER
+}
+
+enum Status {
+  ACTIVE
+  PENDING
+  BANNED
+  LEFT
+}
+
+enum ReactionType {
+  LIKE
+  LOVE
+  LAUGH
+  WOW
+  SAD
+  ANGRY
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,39 @@
+import { PrismaClient, Role } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const user = await prisma.user.upsert({
+    where: { email: 'victor@example.com' },
+    update: {},
+    create: {
+      email: 'victor@example.com',
+      displayName: 'Victor',
+    },
+  });
+
+  await prisma.group.upsert({
+    where: { groupId: 'family-2025' },
+    update: {},
+    create: {
+      groupName: 'Family 2025',
+      groupId: 'family-2025',
+      createdById: user.id,
+      members: {
+        create: {
+          userId: user.id,
+          role: Role.ADMIN,
+        },
+      },
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class AppController {
+  @Get()
+  getHealth() {
+    return { status: 'ok' };
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
+import { GroupsModule } from './groups/groups.module';
+import { UsersModule } from './users/users.module';
+import { MembersModule } from './members/members.module';
+import { PostsModule } from './posts/posts.module';
+import { CommentsModule } from './comments/comments.module';
+import { ReactionsModule } from './reactions/reactions.module';
+import { InvitesModule } from './invites/invites.module';
+import { AppController } from './app.controller';
+
+@Module({
+  imports: [
+    AuthModule,
+    UsersModule,
+    GroupsModule,
+    MembersModule,
+    PostsModule,
+    CommentsModule,
+    ReactionsModule,
+    InvitesModule,
+  ],
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginDto } from './login.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private authService: AuthService) {}
+
+  @Post('login')
+  async login(@Body() dto: LoginDto) {
+    const user = await this.authService.validateUser(dto.email, dto.displayName);
+    const token = this.authService.generateToken(user.id);
+    return { token, user: { id: user.id, email: user.email, displayName: user.displayName } };
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtAuthGuard } from './jwt.guard';
+import { PrismaClient } from '@prisma/client';
+
+@Module({
+  providers: [AuthService, JwtAuthGuard, PrismaClient],
+  controllers: [AuthController],
+  exports: [JwtAuthGuard, AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class AuthService {
+  constructor(private prisma: PrismaClient) {}
+
+  async validateUser(email: string, displayName?: string) {
+    const user = await this.prisma.user.upsert({
+      where: { email },
+      update: {},
+      create: { email, displayName },
+    });
+    return user;
+  }
+
+  generateToken(userId: string) {
+    const secret = process.env.JWT_SECRET || 'secret';
+    return jwt.sign({ sub: userId }, secret, { expiresIn: '7d' });
+  }
+}

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private prisma: PrismaClient) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const auth = request.headers['authorization'];
+    if (!auth) throw new UnauthorizedException('Missing token');
+    const [scheme, token] = auth.split(' ');
+    if (scheme !== 'Bearer' || !token) throw new UnauthorizedException('Invalid token');
+    try {
+      const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as { sub: string };
+      const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
+      if (!user) throw new UnauthorizedException('User not found');
+      request.user = { id: user.id };
+      return true;
+    } catch (e) {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+}

--- a/src/auth/login.dto.ts
+++ b/src/auth/login.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  displayName?: string;
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class CommentsModule {}

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,21 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message =
+      exception instanceof HttpException
+        ? exception.message
+        : 'Internal server error';
+
+    response.status(status).json({ error: message });
+  }
+}

--- a/src/groups/dto/create-group.dto.ts
+++ b/src/groups/dto/create-group.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+
+export class CreateGroupDto {
+  @Matches(/^[a-z0-9-]{3,30}$/)
+  groupId: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  groupName: string;
+
+  @IsOptional()
+  @IsString()
+  password?: string;
+}

--- a/src/groups/dto/join-group.dto.ts
+++ b/src/groups/dto/join-group.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString, Matches } from 'class-validator';
+
+export class JoinGroupDto {
+  @Matches(/^[a-z0-9-]{3,30}$/)
+  groupId: string;
+
+  @IsOptional()
+  @IsString()
+  password?: string;
+}

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, Param, Post, UseGuards, Req } from '@nestjs/common';
+import { GroupsService } from './groups.service';
+import { CreateGroupDto } from './dto/create-group.dto';
+import { JoinGroupDto } from './dto/join-group.dto';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@Controller('groups')
+export class GroupsController {
+  constructor(private groupsService: GroupsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Req() req, @Body() dto: CreateGroupDto) {
+    return this.groupsService.createGroup(req.user.id, dto.groupName, dto.groupId, dto.password);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('join')
+  join(@Req() req, @Body() dto: JoinGroupDto) {
+    return this.groupsService.joinGroup(req.user.id, dto.groupId, dto.password);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get(':groupId')
+  get(@Param('groupId') groupId: string) {
+    return this.groupsService.getGroup(groupId);
+  }
+}

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GroupsService } from './groups.service';
+import { GroupsController } from './groups.controller';
+import { PrismaClient } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@Module({
+  providers: [GroupsService, PrismaClient, JwtAuthGuard],
+  controllers: [GroupsController],
+})
+export class GroupsModule {}

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaClient, Role } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class GroupsService {
+  constructor(private prisma: PrismaClient) {}
+
+  async createGroup(userId: string, groupName: string, groupId: string, password?: string) {
+    const hash = password ? await bcrypt.hash(password, 10) : undefined;
+    try {
+      return await this.prisma.group.create({
+        data: {
+          groupName,
+          groupId,
+          passwordHash: hash,
+          createdById: userId,
+          members: {
+            create: {
+              userId,
+              role: Role.ADMIN,
+            },
+          },
+        },
+      });
+    } catch (e) {
+      throw new BadRequestException('Group creation failed');
+    }
+  }
+
+  async joinGroup(userId: string, groupId: string, password?: string) {
+    const group = await this.prisma.group.findUnique({ where: { groupId } });
+    if (!group) throw new NotFoundException('Group not found');
+    if (group.passwordHash) {
+      const valid = await bcrypt.compare(password || '', group.passwordHash);
+      if (!valid) throw new ForbiddenException('Invalid password');
+    }
+    return this.prisma.groupMember.upsert({
+      where: { groupId_userId: { groupId: group.id, userId } },
+      update: { status: 'ACTIVE' },
+      create: { groupId: group.id, userId, role: Role.MEMBER },
+    });
+  }
+
+  async getGroup(groupId: string) {
+    const group = await this.prisma.group.findUnique({
+      where: { groupId },
+      include: { members: true, createdBy: true },
+    });
+    if (!group) throw new NotFoundException('Group not found');
+    return {
+      id: group.id,
+      groupId: group.groupId,
+      groupName: group.groupName,
+      createdById: group.createdById,
+      memberCount: group.members.length,
+    };
+  }
+}

--- a/src/invites/invites.module.ts
+++ b/src/invites/invites.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class InvitesModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalFilters(new HttpExceptionFilter());
+  await app.listen(process.env.PORT || 3000);
+}
+bootstrap();

--- a/src/members/members.module.ts
+++ b/src/members/members.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class MembersModule {}

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class PostsModule {}

--- a/src/reactions/reactions.module.ts
+++ b/src/reactions/reactions.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class ReactionsModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,3 @@
+import { Module } from '@nestjs/common';
+@Module({})
+export class UsersModule {}

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+PORT=${PORT:-3000}
+PID=$(lsof -Pi :$PORT -sTCP:LISTEN -t || true)
+if [ -n "$PID" ]; then
+  kill $PID
+fi
+
+npx prisma migrate deploy || true
+npm run start

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2018",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add Prisma schema and seed for users and groups
- scaffold NestJS backend with auth and group modules
- add startup script and configuration

## Testing
- `npx prisma migrate dev --name init_pb` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b83b194df883248330cd5058f78028