### PR TITLE
Switch group APIs to token-based auth

### DIFF
--- a/private_board_backend/pages/api/groups/approve-request.ts
+++ b/private_board_backend/pages/api/groups/approve-request.ts
@@ -1,15 +1,19 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const adminId = req.headers['x-user-id'];
+  const adminId = getUserIdFromReq(req);
   const { userId } = req.body;
 
-  if (typeof adminId !== 'string' || !userId) {
+  if (!adminId) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  if (!userId) {
     return res.status(400).json({ message: 'Missing required fields' });
   }
 

--- a/private_board_backend/pages/api/groups/join-request.ts
+++ b/private_board_backend/pages/api/groups/join-request.ts
@@ -1,16 +1,20 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma'; // 실제 경로에 맞게 조정
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const { invitationCode } = req.body;
-  const userId = req.headers['x-user-id'];
+  const { invitationCode, message } = req.body;
+  if (!invitationCode) {
+    return res.status(400).json({ message: 'Missing invitationCode' });
+  }
 
-  if (!invitationCode || typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing invitationCode or userId' });
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   try {

--- a/private_board_backend/pages/api/groups/join.ts
+++ b/private_board_backend/pages/api/groups/join.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -7,10 +8,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { invitationCode } = req.body;
-  const userId = req.headers['x-user-id']; // 추후 JWT 파싱으로 교체 예정
-
-  if (!invitationCode || !userId) {
+  if (!invitationCode) {
     return res.status(400).json({ message: '필수 정보가 누락되었습니다.' });
+  }
+
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   const group = await prisma.group.findUnique({
@@ -22,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   await prisma.user.update({
-    where: { id: String(userId) },
+    where: { id: userId },
     data: { groupId: group.id },
   });
 

--- a/private_board_backend/pages/api/groups/login.ts
+++ b/private_board_backend/pages/api/groups/login.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { prisma } from '../../../lib/prisma'
 import bcrypt from 'bcryptjs'
+import { prisma } from '../../../lib/prisma'
+import { getUserIdFromReq } from '@/lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -8,10 +9,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { loginId, password } = req.body
-  const userId = req.headers['x-user-id']
+  if (!loginId || !password) {
+    return res.status(400).json({ message: 'Missing credentials' })
+  }
 
-  if (!loginId || !password || typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing credentials or userId' })
+  const userId = getUserIdFromReq(req)
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' })
   }
 
   try {

--- a/private_board_backend/pages/api/groups/pending-requests.ts
+++ b/private_board_backend/pages/api/groups/pending-requests.ts
@@ -1,14 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma'; // 경로 맞게 조정
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const userId = req.headers['x-user-id'];
-  if (typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing user ID' });
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   try {


### PR DESCRIPTION
## Summary
- replace custom `x-user-id` header checks with JWT-based `getUserIdFromReq`
- apply token authentication to group login, join, join-request, approve-request, and pending-requests APIs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b3fec794832491710a208dd756d4