### PR TITLE
Switch group APIs to token-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,15 +416,15 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
 ### 🔐 1. 로그인 기능 수정
 - `AuthService.login()`이 `Map<String, dynamic>` 반환하도록 수정
-- 로그인 시 토큰 + 유저 ID 저장
-- 로그인 성공 후 `GroupHomePage(userId: ...)`로 이동
+- 로그인 시 토큰 + 이메일 저장
+- 로그인 성공 후 `GroupHomePage`로 이동
 
 ### ⚙️ 2. ProviderScope 적용
 - `main.dart`에서 `ProviderScope`로 전체 앱 감싸기
 - 모든 `ref.read(...)` 사용 가능하도록 구성
 
 ### 🧠 3. 상태 관리 구조 구축
-- `tokenProvider`, `userIdProvider` (`auth_provider.dart`) 정의
+- `tokenProvider`, `userEmailProvider` (`auth_provider.dart`) 정의
 - 로그인 시 상태에 저장 → 전역에서 사용 가능
 - `dioProvider`: 자동으로 Authorization 헤더 주입
 
@@ -435,7 +435,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 ### 🖼️ 5. 그룹 UI 구성
 - `GroupHomePage`: 그룹 생성, 참여 버튼 포함
 - `CreateGroupPage`: 그룹 이름/관리자 여부 입력 후 생성
-- `JoinGroupPage`: 초대코드 입력 후 참여 (userId 헤더 전달)
+- `JoinGroupPage`: 초대코드 입력 후 참여 (토큰 사용)
 
 ---
 
@@ -446,14 +446,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 | `No ProviderScope` | `main.dart`에서 `ProviderScope` 적용 |
 | `ref.read()` 사용 불가 | `LoginPage`를 `ConsumerStatefulWidget`으로 변경 |
 | `AuthService.login()` 반환값 bool → 객체 변경 | 상태 저장 및 리디렉션 가능해짐 |
-| 그룹 참여 시 `userId` 전달 오류 | `JoinGroupPage(userId: ...)` 생성자 및 필드 추가 |
+| 그룹 참여 시 토큰 미전달 문제 | `JoinGroupPage`에서 토큰 기반 요청으로 수정 |
 
 ---
 
 ## ✅ 다음 작업
 
 1. `GroupHomePage` 진입 시 **이미 참여한 그룹이면 리다이렉션** 처리
-2. `SharedPreferences` → `token`, `userId`로 자동 로그인 이어가기
+2. `SharedPreferences` → `token`, `userEmail`로 자동 로그인 이어가기
 3. 그룹 내부 글 목록 불러오기 (PostList)
 4. 마니또 기능 기획 및 설계 시작
 

--- a/private_board_backend/pages/api/groups/approve-request.ts
+++ b/private_board_backend/pages/api/groups/approve-request.ts
@@ -1,15 +1,19 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const adminId = req.headers['x-user-id'];
+  const adminId = getUserIdFromReq(req);
   const { userId } = req.body;
 
-  if (typeof adminId !== 'string' || !userId) {
+  if (!adminId) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  if (!userId) {
     return res.status(400).json({ message: 'Missing required fields' });
   }
 

--- a/private_board_backend/pages/api/groups/join-request.ts
+++ b/private_board_backend/pages/api/groups/join-request.ts
@@ -1,16 +1,20 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma'; // 실제 경로에 맞게 조정
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const { invitationCode } = req.body;
-  const userId = req.headers['x-user-id'];
+  const { invitationCode, message } = req.body;
+  if (!invitationCode) {
+    return res.status(400).json({ message: 'Missing invitationCode' });
+  }
 
-  if (!invitationCode || typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing invitationCode or userId' });
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   try {

--- a/private_board_backend/pages/api/groups/join.ts
+++ b/private_board_backend/pages/api/groups/join.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma';
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -7,10 +8,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { invitationCode } = req.body;
-  const userId = req.headers['x-user-id']; // 추후 JWT 파싱으로 교체 예정
-
-  if (!invitationCode || !userId) {
+  if (!invitationCode) {
     return res.status(400).json({ message: '필수 정보가 누락되었습니다.' });
+  }
+
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   const group = await prisma.group.findUnique({
@@ -22,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   await prisma.user.update({
-    where: { id: String(userId) },
+    where: { id: userId },
     data: { groupId: group.id },
   });
 

--- a/private_board_backend/pages/api/groups/login.ts
+++ b/private_board_backend/pages/api/groups/login.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { prisma } from '../../../lib/prisma'
 import bcrypt from 'bcryptjs'
+import { prisma } from '../../../lib/prisma'
+import { getUserIdFromReq } from '@/lib/auth'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -8,10 +9,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { loginId, password } = req.body
-  const userId = req.headers['x-user-id']
+  if (!loginId || !password) {
+    return res.status(400).json({ message: 'Missing credentials' })
+  }
 
-  if (!loginId || !password || typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing credentials or userId' })
+  const userId = getUserIdFromReq(req)
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' })
   }
 
   try {

--- a/private_board_backend/pages/api/groups/pending-requests.ts
+++ b/private_board_backend/pages/api/groups/pending-requests.ts
@@ -1,14 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { prisma } from '@/lib/prisma'; // 경로 맞게 조정
+import { getUserIdFromReq } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ message: 'Method not allowed' });
   }
 
-  const userId = req.headers['x-user-id'];
-  if (typeof userId !== 'string') {
-    return res.status(400).json({ message: 'Missing user ID' });
+  const userId = getUserIdFromReq(req);
+  if (!userId) {
+    return res.status(401).json({ message: 'Unauthorized' });
   }
 
   try {

--- a/private_board_frontend/lib/main.dart
+++ b/private_board_frontend/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'pages/login_page.dart';
-import 'pages/group_home_page.dart';
 import 'pages/welcome_page.dart';
 import 'services/auth_service.dart';
 
@@ -18,13 +17,12 @@ class MyApp extends StatelessWidget {
 
   Future<Widget> getStartPage() async {
     final token = await AuthService.getToken();
-    final userId = await AuthService.getUserId();
     final email = await AuthService.getUserEmail();
     print('앱 시작 토큰 체크: "$token"'); // (디버깅용)
-    if (token == null || token.isEmpty || userId == null || email == null) {
+    if (token == null || token.isEmpty || email == null) {
       return const LoginPage();
     } else {
-      return WelcomePage(userId: userId, email: email);
+      return WelcomePage(email: email);
     }
   }
 

--- a/private_board_frontend/lib/pages/create_group_page.dart
+++ b/private_board_frontend/lib/pages/create_group_page.dart
@@ -131,7 +131,6 @@ class _CreateGroupPageState extends ConsumerState<CreateGroupPage> {
                 final name = nameController.text.trim();
                 final gid = idController.text.trim();
                 final pw  = pwController.text;
-                final userId = ref.watch(userIdProvider);
 
 
                 // 클라이언트 측 유효성 검사
@@ -162,7 +161,6 @@ class _CreateGroupPageState extends ConsumerState<CreateGroupPage> {
                     groupId: gid,
                     password: pw,
                     token: token,
-                    userId : userId,
                   );
 
                   if (result['status'] == 'conflict') {

--- a/private_board_frontend/lib/pages/group_home_page.dart
+++ b/private_board_frontend/lib/pages/group_home_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
+import '../providers/auth_provider.dart';
 import 'create_group_page.dart';
 import 'join_group_page.dart';
 import 'post_list_page.dart';
 
 class GroupHomePage extends ConsumerStatefulWidget {
-  final String userId;
-  const GroupHomePage({required this.userId, Key? key}) : super(key: key);
+  const GroupHomePage({Key? key}) : super(key: key);
 
   @override
   ConsumerState<GroupHomePage> createState() => _GroupHomePageState();
@@ -25,8 +25,9 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
 
   Future<void> _loadGroups() async {
     final service = ref.read(groupServiceProvider);
+    final token = ref.read(tokenProvider);
     try {
-      final data = await service.getGroups(userId: widget.userId);
+      final data = await service.getGroups(token);
       setState(() {
         groups = data;
         _loading = false;
@@ -85,11 +86,11 @@ class _GroupHomePageState extends ConsumerState<GroupHomePage> {
                       const SizedBox(width: 12),
                       ElevatedButton(
                         onPressed: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (_) => JoinGroupPage(userId: widget.userId)),
-                          );
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (_) => const JoinGroupPage()),
+                            );
                         },
                         child: const Text('그룹 참여'),
                       ),

--- a/private_board_frontend/lib/pages/join_group_page.dart
+++ b/private_board_frontend/lib/pages/join_group_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/group_provider.dart';
+import '../providers/auth_provider.dart';
 
 class JoinGroupPage extends ConsumerStatefulWidget {
-  final String userId;
-  const JoinGroupPage({Key? key, required this.userId}) : super(key: key); // ✅ 수정
+  const JoinGroupPage({Key? key}) : super(key: key);
 
 
   @override
@@ -49,11 +49,12 @@ class _JoinGroupPageState extends ConsumerState<JoinGroupPage> {
             ElevatedButton(
               onPressed: () async {
                 final groupService = ref.read(groupServiceProvider);
+                final token = ref.read(tokenProvider);
                 try {
                   final result = await groupService.joinGroupByCredential(
                     groupId: idController.text,
                     password: pwController.text,
-                    userId: widget.userId,
+                    token: token,
                   );
                   if (context.mounted) {
                     showDialog(

--- a/private_board_frontend/lib/pages/login_page.dart
+++ b/private_board_frontend/lib/pages/login_page.dart
@@ -24,19 +24,17 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
     if (response != null && mounted) {
       final token = response['token'];
-      final userId = response['user']['id'];
       final email = response['user']['email'];
 
       // 전역 상태에 저장
       ref.read(tokenProvider.notifier).state = token;
-      ref.read(userIdProvider.notifier).state = userId;
       ref.read(userEmailProvider.notifier).state = email;
 
       // 그룹 선택 페이지로 이동
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-          builder: (_) => WelcomePage(userId: userId, email: email),
+          builder: (_) => WelcomePage(email: email),
         ),
       );
     } else {

--- a/private_board_frontend/lib/pages/welcome_page.dart
+++ b/private_board_frontend/lib/pages/welcome_page.dart
@@ -6,9 +6,8 @@ import 'group_home_page.dart';
 import 'login_page.dart';
 
 class WelcomePage extends ConsumerWidget {
-  final String userId;
   final String email;
-  const WelcomePage({Key? key, required this.userId, required this.email}) : super(key: key);
+  const WelcomePage({Key? key, required this.email}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -32,7 +31,7 @@ class WelcomePage extends ConsumerWidget {
               onPressed: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => GroupHomePage(userId: userId)),
+                  MaterialPageRoute(builder: (_) => const GroupHomePage()),
                 );
               },
               child: const Text('그룹 목록 보기'),
@@ -42,7 +41,6 @@ class WelcomePage extends ConsumerWidget {
               onPressed: () async {
                 await AuthService.logout();
                 ref.read(tokenProvider.notifier).state = '';
-                ref.read(userIdProvider.notifier).state = '';
                 ref.read(userEmailProvider.notifier).state = '';
                 if (context.mounted) {
                   Navigator.pushAndRemoveUntil(

--- a/private_board_frontend/lib/providers/auth_provider.dart
+++ b/private_board_frontend/lib/providers/auth_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final tokenProvider = StateProvider<String>((ref) => '');
-final userIdProvider = StateProvider<String>((ref) => '');
 final userEmailProvider = StateProvider<String>((ref) => '');

--- a/private_board_frontend/lib/routes/app_routes.dart
+++ b/private_board_frontend/lib/routes/app_routes.dart
@@ -15,5 +15,5 @@ final Map<String, WidgetBuilder> appRoutes = {
   '/write': (context) => const WritePage(),
   '/profile': (context) => const ProfilePage(),
   '/join-group': (context) => const JoinGroupPage(),
-  '/group': (context) => const GroupHomePage(userId: ''), // 👉 추후 실제 userId 넘길 것
+  '/group': (context) => const GroupHomePage(),
 };

--- a/private_board_frontend/lib/services/auth_service.dart
+++ b/private_board_frontend/lib/services/auth_service.dart
@@ -25,7 +25,7 @@ class AuthService {
     }
   }
 
-  /// 🔑 로그인 및 토큰/유저ID 저장
+  /// 🔑 로그인 및 토큰 저장
   static Future<Map<String, dynamic>?> login(String email, String password) async {
     final dio = Dio();
     try {
@@ -42,13 +42,11 @@ class AuthService {
       print('로그인 응답 데이터: ${response.data}');
 
       final token = response.data['accessToken'] ?? response.data['token'];
-      final userId = response.data['user']?['id'];
       final userEmail = response.data['user']?['email'];
 
-      if (token != null && userId != null && userEmail != null) {
+      if (token != null && userEmail != null) {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('accessToken', token);
-        await prefs.setString('userId', userId);
         await prefs.setString('userEmail', userEmail);
         return response.data; // 전체 response 반환
       }
@@ -64,23 +62,16 @@ class AuthService {
     return prefs.getString('accessToken');
   }
 
-  /// 현재 저장된 유저 ID 가져오기
-  static Future<String?> getUserId() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString('userId');
-  }
-
   /// 현재 저장된 유저 이메일 가져오기
   static Future<String?> getUserEmail() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString('userEmail');
   }
 
-  /// 로그아웃 (토큰 + 유저ID 삭제)
+  /// 로그아웃 (토큰 + 유저이메일 삭제)
   static Future<void> logout() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('accessToken');
-    await prefs.remove('userId');
     await prefs.remove('userEmail');
   }
 


### PR DESCRIPTION
## Summary
- replace custom `x-user-id` header checks with JWT-based `getUserIdFromReq`
- apply token authentication to group login, join, join-request, approve-request, and pending-requests APIs
- pass auth token through frontend navigation and store email/token without user IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b9b3fec794832491710a208dd756d4