### PR TITLE
feat: add group ID availability check endpoint

### DIFF
--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards, Req } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards, Req, Query } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { JoinGroupDto } from './dto/join-group.dto';
@@ -18,6 +18,12 @@ export class GroupsController {
   @Post('join')
   join(@Req() req, @Body() dto: JoinGroupDto) {
     return this.groupsService.joinGroup(req.user.id, dto.groupId, dto.password);
+  }
+
+  @Get('check-id')
+  async checkId(@Query('groupId') groupId: string) {
+    const available = await this.groupsService.isGroupIdAvailable(groupId);
+    return { available };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -56,4 +56,13 @@ export class GroupsService {
       memberCount: group.members.length,
     };
   }
+
+  async isGroupIdAvailable(groupId: string) {
+    if (!groupId) throw new BadRequestException('groupId is required');
+    const existing = await this.prisma.group.findUnique({
+      where: { groupId },
+      select: { id: true },
+    });
+    return !existing;
+  }
 }


### PR DESCRIPTION
## Summary
- add service method to verify whether a group ID is available
- expose unauthenticated GET /groups/check-id endpoint returning availability

## Testing
- ⚠️ `npm test` *(missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bedde8cfd083249a891851ced978af