### PR TITLE
feat: add posts CRUD and invites API

### DIFF
--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -31,11 +31,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     try {
       // 🔍 3. 유저가 해당 그룹 소속인지 확인
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
+      const membership = await prisma.groupMember.findFirst({
+        where: { groupId, userId },
       })
 
-      if (!user || user.groupId !== groupId) {
+      if (!membership) {
         return res.status(403).json({ message: 'User is not a member of this group' })
       }
 

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -3,8 +3,10 @@ import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
 import { PrismaClient } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.guard';
+import { InvitesModule } from '../invites/invites.module';
 
 @Module({
+  imports: [InvitesModule],
   providers: [GroupsService, PrismaClient, JwtAuthGuard],
   controllers: [GroupsController],
 })

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -1,15 +1,16 @@
 import { Injectable, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { PrismaClient, Role } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
+import { InvitesService } from '../invites/invites.service';
 
 @Injectable()
 export class GroupsService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaClient, private invitesService: InvitesService) {}
 
   async createGroup(userId: string, groupName: string, groupId: string, password?: string) {
     const hash = password ? await bcrypt.hash(password, 10) : undefined;
     try {
-      return await this.prisma.group.create({
+      const group = await this.prisma.group.create({
         data: {
           groupName,
           groupId,
@@ -23,6 +24,8 @@ export class GroupsService {
           },
         },
       });
+      await this.invitesService.createCode(userId, group.id);
+      return group;
     } catch (e) {
       throw new BadRequestException('Group creation failed');
     }

--- a/src/invites/invites.controller.ts
+++ b/src/invites/invites.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { InvitesService } from './invites.service';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@Controller('invites')
+export class InvitesController {
+  constructor(private invitesService: InvitesService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Req() req, @Body() body: { groupId: string; expiresAt?: string; maxUses?: number }) {
+    const expiresAt = body.expiresAt ? new Date(body.expiresAt) : undefined;
+    return this.invitesService.createCode(req.user.id, body.groupId, expiresAt, body.maxUses);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get(':code')
+  findOne(@Param('code') code: string) {
+    return this.invitesService.getCode(code);
+  }
+
+  @Get(':code/verify')
+  verify(@Param('code') code: string) {
+    return this.invitesService.verifyCode(code);
+  }
+}

--- a/src/invites/invites.module.ts
+++ b/src/invites/invites.module.ts
@@ -1,3 +1,12 @@
 import { Module } from '@nestjs/common';
-@Module({})
+import { InvitesService } from './invites.service';
+import { InvitesController } from './invites.controller';
+import { PrismaClient } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@Module({
+  providers: [InvitesService, PrismaClient, JwtAuthGuard],
+  controllers: [InvitesController],
+  exports: [InvitesService],
+})
 export class InvitesModule {}

--- a/src/invites/invites.service.ts
+++ b/src/invites/invites.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { randomBytes } from 'crypto';
+
+@Injectable()
+export class InvitesService {
+  constructor(private prisma: PrismaClient) {}
+
+  async createCode(userId: string, groupId: string, expiresAt?: Date, maxUses?: number) {
+    const code = randomBytes(3).toString('hex');
+    return this.prisma.inviteCode.create({
+      data: {
+        groupId,
+        code,
+        expiresAt,
+        maxUses,
+        createdById: userId,
+      },
+    });
+  }
+
+  async getCode(code: string) {
+    const invite = await this.prisma.inviteCode.findUnique({ where: { code } });
+    if (!invite) throw new NotFoundException('Invite code not found');
+    return invite;
+  }
+
+  async verifyCode(code: string) {
+    const invite = await this.prisma.inviteCode.findUnique({ where: { code } });
+    if (!invite) throw new NotFoundException('Invalid invite code');
+    if (invite.expiresAt && invite.expiresAt < new Date()) {
+      throw new BadRequestException('Invite code expired');
+    }
+    if (invite.maxUses && invite.useCount >= invite.maxUses) {
+      throw new BadRequestException('Invite code has been used up');
+    }
+    return invite;
+  }
+}

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,0 +1,12 @@
+import { IsString } from 'class-validator';
+
+export class CreatePostDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  content: string;
+
+  @IsString()
+  groupId: string;
+}

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdatePostDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  content?: string;
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post as HttpPost, Query, Req, UseGuards } from '@nestjs/common';
+import { PostsService } from './posts.service';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('posts')
+export class PostsController {
+  constructor(private postsService: PostsService) {}
+
+  @HttpPost()
+  create(@Req() req, @Body() dto: CreatePostDto) {
+    return this.postsService.createPost(req.user.id, dto.groupId, dto.title, dto.content);
+  }
+
+  @Get()
+  findAll(@Query('groupId') groupId?: string) {
+    return this.postsService.findAll(groupId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.postsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Req() req, @Param('id') id: string, @Body() dto: UpdatePostDto) {
+    return this.postsService.updatePost(req.user.id, id, dto.title, dto.content);
+  }
+
+  @Delete(':id')
+  remove(@Req() req, @Param('id') id: string) {
+    return this.postsService.deletePost(req.user.id, id);
+  }
+}

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,3 +1,11 @@
 import { Module } from '@nestjs/common';
-@Module({})
+import { PostsService } from './posts.service';
+import { PostsController } from './posts.controller';
+import { PrismaClient } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt.guard';
+
+@Module({
+  providers: [PostsService, PrismaClient, JwtAuthGuard],
+  controllers: [PostsController],
+})
 export class PostsModule {}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PostsService {
+  constructor(private prisma: PrismaClient) {}
+
+  async createPost(userId: string, groupId: string, title: string, content: string) {
+    const membership = await this.prisma.groupMember.findFirst({
+      where: { groupId, userId },
+    });
+    if (!membership) {
+      throw new ForbiddenException('User is not a member of this group');
+    }
+    return this.prisma.post.create({
+      data: { title, content, groupId, authorId: userId },
+    });
+  }
+
+  async findAll(groupId?: string) {
+    return this.prisma.post.findMany({
+      where: groupId ? { groupId } : undefined,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        author: {
+          select: { id: true, email: true },
+        },
+      },
+    });
+  }
+
+  async findOne(id: string) {
+    const post = await this.prisma.post.findUnique({
+      where: { id },
+      include: {
+        author: {
+          select: { id: true, email: true },
+        },
+      },
+    });
+    if (!post) throw new NotFoundException('Post not found');
+    return post;
+  }
+
+  async updatePost(userId: string, id: string, title?: string, content?: string) {
+    const post = await this.prisma.post.findUnique({ where: { id } });
+    if (!post) throw new NotFoundException('Post not found');
+    if (post.authorId !== userId) {
+      throw new ForbiddenException('Not your post');
+    }
+    return this.prisma.post.update({
+      where: { id },
+      data: { title, content },
+    });
+  }
+
+  async deletePost(userId: string, id: string) {
+    const post = await this.prisma.post.findUnique({ where: { id } });
+    if (!post) throw new NotFoundException('Post not found');
+    if (post.authorId !== userId) {
+      throw new ForbiddenException('Not your post');
+    }
+    return this.prisma.post.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## Summary
- add NestJS posts service/controller with CRUD operations and group membership checks
- update Next.js posts route to verify membership via groupMember relation
- add invites service/controller to manage invite codes and verify them
- generate a default invite code when creating a group

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Cannot find module '@prisma/client', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c18c75a4f883248662f261dfe79386