### PR TITLE
refactor: centralize jwt secret handling

### DIFF
--- a/private_board_backend/lib/auth.ts
+++ b/private_board_backend/lib/auth.ts
@@ -2,7 +2,7 @@
 import jwt from "jsonwebtoken";
 import type { NextApiRequest } from "next";
 
-type JwtPayload = {
+export type JwtPayload = {
   userId?: string;     // 앱에서 쓰던 형태
   sub?: string;        // 이전(또는 다른 서비스)에서 쓰던 형태
   email?: string;
@@ -10,15 +10,32 @@ type JwtPayload = {
   exp?: number;
 };
 
+let cachedSecret: string | null = null;
+
+export function getJwtSecret(): string {
+  if (cachedSecret) {
+    return cachedSecret;
+  }
+
+  const secret = process.env.JWT_SECRET?.trim();
+
+  if (!secret) {
+    const message = "JWT_SECRET environment variable must be provided";
+    console.error(`[AUTH] ${message}`);
+    throw new Error(message);
+  }
+
+  cachedSecret = secret;
+  return cachedSecret;
+}
+
 export function signJwt(payload: JwtPayload) {
-  const secret = process.env.JWT_SECRET!;
-  return jwt.sign(payload, secret, { expiresIn: "7d" });
+  return jwt.sign(payload, getJwtSecret(), { expiresIn: "7d" });
 }
 
 export function verifyJwt(token: string): JwtPayload | null {
   try {
-    const secret = process.env.JWT_SECRET!;
-    return jwt.verify(token, secret) as JwtPayload;
+    return jwt.verify(token, getJwtSecret()) as JwtPayload;
   } catch {
     return null;
   }

--- a/private_board_backend/lib/verifyToken.ts
+++ b/private_board_backend/lib/verifyToken.ts
@@ -1,14 +1,21 @@
 // lib/verifyToken.ts
-import jwt from 'jsonwebtoken'
-import { JwtPayload } from 'jsonwebtoken'
+import { verifyJwt } from './auth'
 
-const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
-
-export function verifyToken(token: string): { userId: string, email: string } | null {
-  try {
-    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload
-    return { userId: decoded.sub as string, email: decoded.email }
-  } catch (error) {
+export function verifyToken(token: string | undefined): { userId: string, email?: string } | null {
+  if (!token) {
     return null
   }
+
+  const decoded = verifyJwt(token)
+  if (!decoded) {
+    return null
+  }
+
+  const userId = decoded.sub ?? decoded.userId
+
+  if (!userId) {
+    return null
+  }
+
+  return { userId, email: decoded.email }
 }

--- a/private_board_backend/pages/api/auth/login.ts
+++ b/private_board_backend/pages/api/auth/login.ts
@@ -3,10 +3,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
-import jwt from 'jsonwebtoken'
+import { signJwt } from '@/lib/auth'
 
 const prisma = new PrismaClient()
-const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -31,11 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ message: '이메일 또는 비밀번호가 올바르지 않습니다.' })
     }
 
-    const token = jwt.sign(
-      { sub: user.id, email: user.email },
-      JWT_SECRET,
-      { expiresIn: '7d' }
-    )
+    const token = signJwt({ sub: user.id, email: user.email })
 
     return res.status(200).json({
       token,

--- a/private_board_backend/pages/api/posts/[id].ts
+++ b/private_board_backend/pages/api/posts/[id].ts
@@ -1,28 +1,32 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { PrismaClient } from '@prisma/client'
-import jwt from 'jsonwebtoken'
+import { getTokenFromReq, verifyJwt } from '@/lib/auth'
 
 const prisma = new PrismaClient()
-const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
+
+function getAuthenticatedUserId(req: NextApiRequest, res: NextApiResponse): string | null {
+  const token = getTokenFromReq(req)
+  if (!token) {
+    res.status(401).json({ message: 'No token provided' })
+    return null
+  }
+
+  const decoded = verifyJwt(token)
+  const userId = decoded?.userId ?? decoded?.sub
+  if (!userId) {
+    res.status(401).json({ message: 'Invalid token' })
+    return null
+  }
+
+  return userId
+}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query
 
   if (req.method === 'PUT') {
-    const authHeader = req.headers.authorization
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return res.status(401).json({ message: 'No token provided' })
-    }
-
-    const token = authHeader.split(' ')[1]
-    let userId: string
-
-    try {
-      const decoded = jwt.verify(token, JWT_SECRET) as { userId: string }
-      userId = decoded.userId
-    } catch (err) {
-      return res.status(401).json({ message: 'Invalid token' })
-    }
+    const userId = getAuthenticatedUserId(req, res)
+    if (!userId) return
 
     const { title, content } = req.body
     if (!title || !content) {
@@ -56,20 +60,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'DELETE') {
-    const authHeader = req.headers.authorization
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return res.status(401).json({ message: 'No token provided' })
-    }
-
-    const token = authHeader.split(' ')[1]
-    let userId: string
-
-    try {
-      const decoded = jwt.verify(token, JWT_SECRET) as { userId: string }
-      userId = decoded.userId
-    } catch (err) {
-      return res.status(401).json({ message: 'Invalid token' })
-    }
+    const userId = getAuthenticatedUserId(req, res)
+    if (!userId) return
     // 🔐 권한 체크
     const existingPost = await prisma.post.findUnique({
       where: { id: String(id) }

--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -1,25 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { PrismaClient } from '@prisma/client'
-import jwt from 'jsonwebtoken'
+import { getTokenFromReq, verifyJwt } from '@/lib/auth'
 
 const prisma = new PrismaClient()
-const JWT_SECRET = process.env.JWT_SECRET || 'default_secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
     // 🔐 1. 토큰 검증
-    const authHeader = req.headers.authorization
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const token = getTokenFromReq(req)
+    if (!token) {
       return res.status(401).json({ message: 'No token provided' })
     }
 
-    const token = authHeader.split(' ')[1]
-    let userId: string
-
-    try {
-      const decoded = jwt.verify(token, JWT_SECRET) as { sub: string }
-      userId = decoded.sub
-    } catch (err) {
+    const decoded = verifyJwt(token)
+    const userId = decoded?.sub ?? decoded?.userId
+    if (!userId) {
       return res.status(401).json({ message: 'Invalid token' })
     }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
-import * as jwt from 'jsonwebtoken';
+import { signJwt } from './jwt.util';
 
 @Injectable()
 export class AuthService {
@@ -16,7 +16,6 @@ export class AuthService {
   }
 
   generateToken(userId: string) {
-    const secret = process.env.JWT_SECRET || 'secret';
-    return jwt.sign({ sub: userId }, secret, { expiresIn: '7d' });
+    return signJwt({ sub: userId });
   }
 }

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import * as jwt from 'jsonwebtoken';
 import { PrismaClient } from '@prisma/client';
+import { verifyJwt } from './jwt.util';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
@@ -13,8 +13,13 @@ export class JwtAuthGuard implements CanActivate {
     const [scheme, token] = auth.split(' ');
     if (scheme !== 'Bearer' || !token) throw new UnauthorizedException('Invalid token');
     try {
-      const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret') as { sub: string };
-      const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
+      const payload = verifyJwt(token);
+      const userId = payload?.sub ?? payload?.userId;
+      if (!userId) {
+        throw new UnauthorizedException('Invalid token');
+      }
+
+      const user = await this.prisma.user.findUnique({ where: { id: userId } });
       if (!user) throw new UnauthorizedException('User not found');
       request.user = { id: user.id };
       return true;

--- a/src/auth/jwt.util.ts
+++ b/src/auth/jwt.util.ts
@@ -1,0 +1,40 @@
+import * as jwt from 'jsonwebtoken'
+
+export interface JwtPayload {
+  userId?: string
+  sub?: string
+  email?: string
+  iat?: number
+  exp?: number
+}
+
+let cachedSecret: string | null = null
+
+export function getJwtSecret(): string {
+  if (cachedSecret) {
+    return cachedSecret
+  }
+
+  const secret = process.env.JWT_SECRET?.trim()
+
+  if (!secret) {
+    const message = 'JWT_SECRET environment variable must be provided'
+    console.error(`[AUTH] ${message}`)
+    throw new Error(message)
+  }
+
+  cachedSecret = secret
+  return cachedSecret
+}
+
+export function signJwt(payload: JwtPayload) {
+  return jwt.sign(payload, getJwtSecret(), { expiresIn: '7d' })
+}
+
+export function verifyJwt(token: string): JwtPayload | null {
+  try {
+    return jwt.verify(token, getJwtSecret()) as JwtPayload
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- require JWT_SECRET to be present and non-empty through shared helpers in both Next.js and Nest.js codepaths
- refactor API handlers and token utilities to rely on the centralized helpers instead of inline defaults

## Testing
- npm install *(fails: 403 Forbidden when fetching @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b72e96188324adff237ea50380a9