### PR TITLE
Use Prisma singleton in Next.js API routes

### DIFF
--- a/private_board_backend/pages/api/auth/login.ts
+++ b/private_board_backend/pages/api/auth/login.ts
@@ -1,11 +1,9 @@
 // pages/api/auth/login.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { signJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/private_board_backend/pages/api/auth/register.ts
+++ b/private_board_backend/pages/api/auth/register.ts
@@ -1,10 +1,8 @@
 // pages/api/auth/register.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/private_board_backend/pages/api/me.ts
+++ b/private_board_backend/pages/api/me.ts
@@ -1,10 +1,8 @@
 // pages/api/me.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { verifyToken } from '@/lib/verifyToken'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {

--- a/private_board_backend/pages/api/posts/[id].ts
+++ b/private_board_backend/pages/api/posts/[id].ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { getTokenFromReq, verifyJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 function getAuthenticatedUserId(req: NextApiRequest, res: NextApiResponse): string | null {
   const token = getTokenFromReq(req)

--- a/private_board_backend/pages/api/posts/[id]/reactions.ts
+++ b/private_board_backend/pages/api/posts/[id]/reactions.ts
@@ -1,8 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { verifyToken } from '../../../../lib/verifyToken'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 
 

--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { getTokenFromReq, verifyJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {


### PR DESCRIPTION
## Summary
- replace per-request PrismaClient instantiations in the Next.js API handlers with the shared client from lib/prisma
- ensure posts, auth, and reactions routes import the singleton to prevent connection leaks

## Testing
- npm run lint *(fails: Next.js lint cannot load next.config.ts and requires next.config.js or next.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c1eb9f288324bb83dd6956ee43aa