### PR TITLE
Use Prisma singleton across backend services and align JWT payload

### DIFF
--- a/private_board_backend/lib/auth.ts
+++ b/private_board_backend/lib/auth.ts
@@ -30,7 +30,15 @@ export function getJwtSecret(): string {
 }
 
 export function signJwt(payload: JwtPayload) {
-  return jwt.sign(payload, getJwtSecret(), { expiresIn: "7d" });
+  const { sub, userId, ...rest } = payload;
+  const resolvedId = sub ?? userId;
+
+  const normalizedPayload: JwtPayload = {
+    ...rest,
+    ...(resolvedId != null ? { sub: resolvedId, userId: resolvedId } : {}),
+  };
+
+  return jwt.sign(normalizedPayload, getJwtSecret(), { expiresIn: "7d" });
 }
 
 export function verifyJwt(token: string): JwtPayload | null {

--- a/private_board_backend/pages/api/auth/login.ts
+++ b/private_board_backend/pages/api/auth/login.ts
@@ -1,11 +1,9 @@
 // pages/api/auth/login.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { signJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/private_board_backend/pages/api/auth/register.ts
+++ b/private_board_backend/pages/api/auth/register.ts
@@ -1,10 +1,8 @@
 // pages/api/auth/register.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import bcrypt from 'bcryptjs'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {

--- a/private_board_backend/pages/api/me.ts
+++ b/private_board_backend/pages/api/me.ts
@@ -1,10 +1,8 @@
 // pages/api/me.ts
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { verifyToken } from '@/lib/verifyToken'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {

--- a/private_board_backend/pages/api/posts/[id].ts
+++ b/private_board_backend/pages/api/posts/[id].ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { getTokenFromReq, verifyJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 function getAuthenticatedUserId(req: NextApiRequest, res: NextApiResponse): string | null {
   const token = getTokenFromReq(req)

--- a/private_board_backend/pages/api/posts/[id]/reactions.ts
+++ b/private_board_backend/pages/api/posts/[id]/reactions.ts
@@ -1,8 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { verifyToken } from '../../../../lib/verifyToken'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 
 

--- a/private_board_backend/pages/api/posts/index.ts
+++ b/private_board_backend/pages/api/posts/index.ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { PrismaClient } from '@prisma/client'
 import { getTokenFromReq, verifyJwt } from '@/lib/auth'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,10 +7,12 @@ import { PostsModule } from './posts/posts.module';
 import { CommentsModule } from './comments/comments.module';
 import { ReactionsModule } from './reactions/reactions.module';
 import { InvitesModule } from './invites/invites.module';
+import { PrismaModule } from './prisma/prisma.module';
 import { AppController } from './app.controller';
 
 @Module({
   imports: [
+    PrismaModule,
     AuthModule,
     UsersModule,
     GroupsModule,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtAuthGuard } from './jwt.guard';
-import { PrismaClient } from '@prisma/client';
 
 @Module({
-  providers: [AuthService, JwtAuthGuard, PrismaClient],
+  providers: [AuthService, JwtAuthGuard],
   controllers: [AuthController],
   exports: [JwtAuthGuard, AuthService],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 import { signJwt } from './jwt.util';
 
 @Injectable()
 export class AuthService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaService) {}
 
   async validateUser(email: string, displayName?: string) {
     const user = await this.prisma.user.upsert({

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -1,10 +1,10 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 import { verifyJwt } from './jwt.util';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();

--- a/src/auth/jwt.util.ts
+++ b/src/auth/jwt.util.ts
@@ -28,7 +28,15 @@ export function getJwtSecret(): string {
 }
 
 export function signJwt(payload: JwtPayload) {
-  return jwt.sign(payload, getJwtSecret(), { expiresIn: '7d' })
+  const { sub, userId, ...rest } = payload
+  const resolvedId = sub ?? userId
+
+  const normalizedPayload: JwtPayload = {
+    ...rest,
+    ...(resolvedId != null ? { sub: resolvedId, userId: resolvedId } : {}),
+  }
+
+  return jwt.sign(normalizedPayload, getJwtSecret(), { expiresIn: '7d' })
 }
 
 export function verifyJwt(token: string): JwtPayload | null {

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
-import { PrismaClient } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import { InvitesModule } from '../invites/invites.module';
 
 @Module({
   imports: [InvitesModule],
-  providers: [GroupsService, PrismaClient, JwtAuthGuard],
+  providers: [GroupsService, JwtAuthGuard],
   controllers: [GroupsController],
 })
 export class GroupsModule {}

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { PrismaClient, Role } from '@prisma/client';
+import { Role } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import { InvitesService } from '../invites/invites.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class GroupsService {
-  constructor(private prisma: PrismaClient, private invitesService: InvitesService) {}
+  constructor(private prisma: PrismaService, private invitesService: InvitesService) {}
 
   async createGroup(userId: string, groupName: string, groupId: string, password?: string) {
     const hash = password ? await bcrypt.hash(password, 10) : undefined;

--- a/src/invites/invites.module.ts
+++ b/src/invites/invites.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 import { InvitesService } from './invites.service';
 import { InvitesController } from './invites.controller';
-import { PrismaClient } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 
 @Module({
-  providers: [InvitesService, PrismaClient, JwtAuthGuard],
+  providers: [InvitesService, JwtAuthGuard],
   controllers: [InvitesController],
   exports: [InvitesService],
 })

--- a/src/invites/invites.service.ts
+++ b/src/invites/invites.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 import { randomBytes } from 'crypto';
 
 @Injectable()
 export class InvitesService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaService) {}
 
   async createCode(userId: string, groupId: string, expiresAt?: Date, maxUses?: number) {
     const code = randomBytes(3).toString('hex');

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
-import { PrismaClient } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 
 @Module({
-  providers: [PostsService, PrismaClient, JwtAuthGuard],
+  providers: [PostsService, JwtAuthGuard],
   controllers: [PostsController],
 })
 export class PostsModule {}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class PostsService {
-  constructor(private prisma: PrismaClient) {}
+  constructor(private prisma: PrismaService) {}
 
   async createPost(userId: string, groupId: string, title: string, content: string) {
     const membership = await this.prisma.groupMember.findFirst({

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}


### PR DESCRIPTION
## Summary
- replace per-request PrismaClient instantiations in the Next.js API handlers with the shared client from lib/prisma
- ensure posts, auth, and reactions routes import the singleton to prevent connection leaks
- normalize the JWT helpers to mirror the user id into both `sub` and `userId` claims so API handlers consistently identify the authenticated user
- register a global Prisma service for the Nest modules so auth, posts, groups, and invites reuse a single client instance

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8c1eb9f288324bb83dd6956ee43aa